### PR TITLE
Create initial tables

### DIFF
--- a/migrations/20260326151227_create_initial_tables.sql
+++ b/migrations/20260326151227_create_initial_tables.sql
@@ -1,0 +1,21 @@
+CREATE TABLE branches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_url TEXT NOT NULL,
+    name TEXT NOT NULL,
+    last_commit_hash TEXT,
+    polling_interval_secs INTEGER NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE subscribers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    branch_id INTEGER NOT NULL,
+    target_repo TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    gh_app_installation_id INTEGER NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (branch_id) REFERENCES branches(id) ON DELETE CASCADE
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use tracing::error;
 use crate::{error::AppError, state::AppState};
 
 mod error;
+mod model;
 mod state;
 
 #[tokio::main]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+#[derive(Debug, Serialize, Deserialize, FromRow)]
+pub struct Branch {
+    pub id: i64,
+    pub repo_url: String,
+    pub name: String,
+    pub last_commit_hash: Option<String>,
+    pub polling_interval_secs: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow)]
+pub struct Subscriber {
+    pub id: i64,
+    pub branch_id: i64,
+    pub target_repo: String,
+    pub event_type: String,
+    pub gh_app_installation_id: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}


### PR DESCRIPTION
Adds a database migration. Paves the way for adding basic tracking of repository branches, and letting users subscribe via a GitHub App.