### PR TITLE
Allow secrets to be safely stored in the worktree

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake .
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm
+
+# Secrets
+*.pem
+.envrc.local


### PR DESCRIPTION
Updates `.gitignore` and adds a reference to `.envrc` to avoid git tracking `.pem` secrets and environment variables.