### PR TITLE
Remove `SELECT` file pattern from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm
-SELECT
 
 # Secrets
 *.pem


### PR DESCRIPTION
In #9 I added the `SELECT` pattern to `.gitignore`, thinking it was a file generated by SQLite or sqlx. Researching I noticed it was probably created by accident by me.