### PR TITLE
Add documentation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error type definitions and implementations.
+
 use std::time::SystemTimeError;
 
 use axum::{
@@ -9,22 +11,38 @@ use tokio::sync::mpsc::error::SendError;
 
 use crate::events::BranchUpdateEvent;
 
+/// Consolidates every application error into a single type.
 #[derive(Debug, Error)]
 pub enum AppError {
+    /// Error encountered during an I/O operation.
     #[error("I/O Error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Error occurred while executing database query or connection.
     #[error("SQLx Error: {0}")]
     Sqlx(#[from] sqlx::Error),
-    #[error("Process failed: {0}")]
-    Process(String),
+
+    /// Failure retrieving or computing system time.
     #[error("System Time Error: {0}")]
     SystemTime(#[from] SystemTimeError),
+
+    /// Error during JWT token generation or validation.
     #[error("JWT Error: {0}")]
     Jwt(#[from] jsonwebtoken::errors::Error),
+
+    /// Failed to send update event to the trigger engine channel.
     #[error("Channel send error: {0}")]
     ChannelSend(#[from] SendError<BranchUpdateEvent>),
+
+    /// Error encountered during HTTP request to GitHub API.
     #[error("Client error: {0}")]
     Client(#[from] reqwest::Error),
+
+    /// A spawned process returned an error or an unsuccessful result.
+    #[error("Process failed: {0}")]
+    Process(String),
+
+    /// A failing HTTP response.
     #[error("Response error: {0}")]
     Response(String),
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,11 @@
+//! Items allowing communication between modules.
+
+/// Signals that a git branch has updated.
 #[derive(Debug, Clone)]
 pub struct BranchUpdateEvent {
+    /// The database ID column of the updated branch.
     pub branch_id: i64,
+
+    /// The hash of the latest commit on the branch.
     pub new_hash: String,
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,9 +1,12 @@
+//! Axum route handlers.
+
 use crate::error::AppError;
 use crate::model::{Branch, CreateBranch, CreateSubscriber, Subscriber};
 use crate::state::AppState;
 use axum::{Json, extract::State};
 use tracing::info;
 
+/// Stores a new [`Branch`] in the database.
 pub async fn create_branch(
     State(state): State<AppState>,
     Json(payload): Json<CreateBranch>,
@@ -22,6 +25,7 @@ pub async fn create_branch(
     Ok(Json(branch))
 }
 
+/// Stores a new [`Subscriber`] in the database.
 pub async fn create_subscriber(
     State(state): State<AppState>,
     Json(payload): Json<CreateSubscriber>,
@@ -44,6 +48,9 @@ pub async fn create_subscriber(
     Ok(Json(subscriber))
 }
 
+/// Gets the branch ID specified in the [`CreateSubscriber`] payload.
+///
+/// If the branch doesn't exist, it is created and its ID is returned.
 async fn get_or_insert_branch_id(
     transaction: &mut sqlx::SqliteConnection,
     payload: &CreateSubscriber,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+
 use axum::{
     Router,
     routing::{get, post},
@@ -25,6 +28,7 @@ async fn main() {
     run_app().await.unwrap_or_else(|e| error!("{e}"));
 }
 
+/// Runs the server, delegating errors to the caller.
 async fn run_app() -> Result<(), AppError> {
     const BRANCH_UPDATE_EVENT_BUFFER_SIZE: usize = 64;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod trigger;
 
 #[tokio::main]
 async fn main() {
-    run_app().await.unwrap_or_else(handle_app_error);
+    run_app().await.unwrap_or_else(|e| error!("{e}"));
 }
 
 async fn run_app() -> Result<(), AppError> {
@@ -52,33 +52,4 @@ async fn run_app() -> Result<(), AppError> {
     token.cancel();
 
     Ok(())
-}
-
-fn handle_app_error(app_error: AppError) {
-    match app_error {
-        AppError::Io(e) => {
-            error!("{e}")
-        }
-        AppError::Sqlx(e) => {
-            error!("{e}")
-        }
-        AppError::Process(e) => {
-            error!("{e}")
-        }
-        AppError::SystemTime(e) => {
-            error!("{e}")
-        }
-        AppError::Jwt(e) => {
-            error!("{e}")
-        }
-        AppError::ChannelSend(e) => {
-            error!("{e}")
-        }
-        AppError::Client(e) => {
-            error!("{e}")
-        }
-        AppError::Response(e) => {
-            error!("{e}")
-        }
-    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,41 +1,102 @@
+//! Data structures representing items stored in database.
+//!
+//! The `Create_` `struct`s represent the payload
+//! to create the corresponding row.
+
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+/// Represents a row in the `branches` table.
 #[derive(Debug, Serialize, Deserialize, FromRow)]
 pub struct Branch {
+    /// Unique database primary key.
     pub id: i64,
+
+    /// Full HTTPS URL of the monitored git repository.
     pub repo_url: String,
+
+    /// Name of the git branch to poll.
     pub name: String,
+
+    /// SHA of the latest commit polled.
+    ///
+    /// `None` if the branch has not been processed.
     pub last_commit_hash: Option<String>,
+
+    /// Has no effect.
     pub polling_interval_secs: i32,
+
+    /// Timestamp when the record was created, in standard SQL `DATETIME` format (`YYYY-MM-DD HH:MM:SS`).
     pub created_at: String,
+
+    /// Timestamp when the record was updated, in standard SQL `DATETIME` format (`YYYY-MM-DD HH:MM:SS`).
     pub updated_at: String,
 }
 
+/// Holds payload data for the creation of a [`Branch`].
 #[derive(Debug, Deserialize)]
 pub struct CreateBranch {
+    /// Determines the value of [`Branch::repo_url`].
     pub repo_url: String,
+
+    /// Determines the value of [`Branch::name`].
     pub name: String,
+
+    /// Determines the value of [`Branch::polling_interval_secs`].
     pub polling_interval_secs: i32,
 }
 
+/// Represents a row in the `subscribers` table.
 #[derive(Debug, Serialize, Deserialize, FromRow)]
 pub struct Subscriber {
+    /// Unique database primary key.
     pub id: i64,
+
+    /// Foreign key to [`Branch::id`].
     pub branch_id: i64,
+
+    /// The repository whose workflow needs to be triggered.
     pub target_repo: String,
+
+    /// Identifies the specific [`repository_dispatch`] event.
+    ///
+    /// The values must contain at most 100 characters.
+    ///
+    /// <!-- LINKS -->
+    /// [`repository_dispatch`]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch
     pub event_type: String,
+
+    /// Allows authenticating as a [GitHub App installation][gh_app_auth].
+    ///
+    /// <!-- LINKS -->
+    /// [gh_app_auth]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
     pub gh_app_installation_id: i64,
+
+    /// Timestamp when the record was created, in standard SQL `DATETIME` format (`YYYY-MM-DD HH:MM:SS`).
     pub created_at: String,
+
+    /// Timestamp when the record was updated, in standard SQL `DATETIME` format (`YYYY-MM-DD HH:MM:SS`).
     pub updated_at: String,
 }
 
+/// Holds payload data for the creation of a [`Subscriber`].
 #[derive(Debug, Deserialize)]
 pub struct CreateSubscriber {
+    /// Determines the value of [`Branch::repo_url`].
     pub source_repo_url: String,
+
+    /// Determines the value of [`Branch::name`].
     pub source_branch_name: String,
+
+    /// Determines the value of [`Branch::polling_interval_secs`].
     pub polling_interval_secs: i64,
+
+    /// Determines the value of [`Subscriber::target_repo`].
     pub target_repo: String,
+
+    /// Determines the value of [`Subscriber::event_type`].
     pub event_type: String,
+
+    /// Determines the value of [`Subscriber::gh_app_installation_id`].
     pub gh_app_installation_id: i64,
 }

--- a/src/polling/branch.rs
+++ b/src/polling/branch.rs
@@ -6,6 +6,7 @@ use crate::{error::AppError, model::Branch, polling::git::get_latest_hash};
 pub(super) struct BranchInfo {
     /// The branch currently stored in the database.
     pub branch: Branch,
+
     /// The actual branch hash.
     pub latest_hash: String,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,11 @@
+//! State of the application.
+
+/// Holds data accessible from each [handler].
+///
+/// <!-- LINKS -->
+/// [handler]: crate::handler
 #[derive(Debug, Clone)]
 pub struct AppState {
+    /// SQLx connection pool for the SQLite database.
     pub db_pool: sqlx::SqlitePool,
 }

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -1,3 +1,5 @@
+//! Authentication and authorization to request services.
+
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -6,12 +8,19 @@ use tracing::info;
 use crate::{error::AppError, model::Subscriber};
 
 /// Payload that GitHub expects in the JWT.
+///
+/// Read more on [GitHub's documentation][jwt_docs].
+///
+/// <!-- LINKS -->
+/// [jwt_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 #[derive(Debug, Serialize, Deserialize)]
 struct GitHubClaims {
     /// Issued at time (UNIX time).
     iat: u64,
+
     /// Expiration time (UNIX time).
     exp: u64,
+
     /// Issuer: GitHub App's Client ID.
     iss: String,
 }
@@ -20,6 +29,7 @@ struct GitHubClaims {
 ///
 /// Implementation based on [GitHub's documentation][jwt_docs].
 ///
+/// <!-- LINKS -->
 /// [jwt_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String, AppError> {
     // TODO: Check if you should use Tokio API.
@@ -43,6 +53,13 @@ pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String,
     Ok(jwt)
 }
 
+/// Requests an Installation Access Token (IAT)
+/// to operate on a GitHub App installation.
+///
+/// Implementation based on [GitHub's documentation][iat_docs].
+///
+/// <!-- LINKS -->
+/// [iat_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
 pub(super) async fn request_iat(
     http_client: &Client,
     jwt: &str,

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -1,3 +1,5 @@
+//! Asynchronous task to trigger remote repository workflows.
+
 use std::env;
 
 use reqwest::Client;
@@ -15,6 +17,10 @@ use crate::{
 
 mod auth;
 
+/// Spawns an asynchronous task to trigger repository workflows.
+///
+/// The spawned task will listen to [`BranchUpdateEvent`]s,
+/// triggering a workflow for each event it receives.
 pub fn start_trigger_engine(
     pool: SqlitePool,
     token: CancellationToken,
@@ -27,6 +33,7 @@ pub fn start_trigger_engine(
     });
 }
 
+/// Controls whether to shut down the trigger engine or process a [`BranchUpdateEvent`].
 async fn trigger_loop(
     pool: SqlitePool,
     http_client: Client,
@@ -42,6 +49,7 @@ async fn trigger_loop(
     info!("Gracefully shutting down trigger engine");
 }
 
+/// Handles a [`BranchUpdateEvent`], handling any possible error.
 async fn handle_branch_update(pool: &SqlitePool, http_client: &Client, event: BranchUpdateEvent) {
     let result = dispatch_events(pool, http_client, event).await;
 
@@ -50,6 +58,7 @@ async fn handle_branch_update(pool: &SqlitePool, http_client: &Client, event: Br
     }
 }
 
+/// Sends a `repository_dispatch` event for each relevant [`Subscriber`].
 async fn dispatch_events(
     pool: &SqlitePool,
     http_client: &Client,
@@ -78,6 +87,7 @@ async fn dispatch_events(
     Ok(())
 }
 
+/// Gets all the [`Subscriber`]s subscribed to the [`BranchUpdateEvent`].
 async fn get_subscribers(
     pool: &SqlitePool,
     event: &BranchUpdateEvent,
@@ -91,6 +101,8 @@ async fn get_subscribers(
     Ok(subscribers)
 }
 
+/// Manages IAT authentication,
+/// and sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn notify_subscriber(
     http_client: &Client,
     jwt: &str,
@@ -102,6 +114,7 @@ async fn notify_subscriber(
     Ok(())
 }
 
+/// Sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn send_repository_dispatch(
     http_client: &Client,
     iat: &str,
@@ -147,6 +160,7 @@ async fn send_repository_dispatch(
     }
 }
 
+/// Creates a new HTTP client.
 fn build_http_client() -> Client {
     const USER_AGENT: &str = "nilirad-relay-server";
 


### PR DESCRIPTION
- Closes #14 

Adds doc comments on all items, which should be helpful for IDE tooltips and analysis in general. I also simplified the server's top-level error handling. I removed the `handle_app_error` function with a more concise inline closure in `main`, leveraging the `Display` implementation of `AppError` instead of `matching` every variant.