### PR TITLE
Check documentation on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
+      - name: Documentation
+        run: cargo doc --locked --all-features --no-deps --document-private-items
+
   test_and_build:
     name: Test and Build
     needs: [lint]


### PR DESCRIPTION
- Closes #27 

Adds a `Documentation` step to the `Lint` job, to catch automatically verifiable issues in documentation.