### PR TITLE
Refactor errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Error type definitions and implementations.
+//! Definitions for common error types.
 
 use axum::{
     http::StatusCode,
@@ -6,15 +6,15 @@ use axum::{
 };
 use thiserror::Error;
 
-/// Consolidates every application error into a single type.
+/// An error happened inside an Axum handler.
 #[derive(Debug, Error)]
-pub enum AppError {
-    /// Error occurred while executing database query or connection.
+pub enum HandlerError {
+    /// Database query execution failure.
     #[error("SQLx Error: {0}")]
-    Sqlx(#[from] sqlx::Error),
+    DbQuery(#[from] sqlx::Error),
 }
 
-impl IntoResponse for AppError {
+impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
         (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,3 +52,26 @@ impl IntoResponse for AppError {
         (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }
 }
+
+/// An error that requires the server to be shut down.
+#[derive(Debug, Error)]
+pub enum FatalError {
+    /// Database is down or URL is incorrect.
+    #[error("Database connection: {0}")]
+    DbConnection(#[from] sqlx::Error),
+
+    /// Could not reserve an IP address with a TCP port
+    /// to connect to the server.
+    #[error("TCP binding: {0}")]
+    TcpBinding(#[source] std::io::Error),
+
+    /// I/O error during server's execution loop.
+    #[error("Serve: {0}")]
+    Serve(#[source] std::io::Error),
+
+    /// HTTP Client creation failed.
+    ///
+    /// The server cannot trigger workflows.
+    #[error("HTTP Client creation: {0}")]
+    ClientCreation(#[from] reqwest::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,9 +69,15 @@ pub enum FatalError {
     #[error("Serve: {0}")]
     Serve(#[source] std::io::Error),
 
-    /// HTTP Client creation failed.
-    ///
-    /// The server cannot trigger workflows.
+    // Docs deferred to inner type.
+    #[allow(clippy::missing_docs_in_private_items)]
     #[error("HTTP Client creation: {0}")]
-    ClientCreation(#[from] reqwest::Error),
+    ClientCreation(#[from] ClientCreationError),
 }
+
+/// HTTP Client creation failed.
+///
+/// The server cannot trigger workflows.
+#[derive(Debug, Error)]
+#[error("HTTP Client creation: {0}")]
+pub struct ClientCreationError(#[from] reqwest::Error);

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,10 +38,6 @@ pub enum AppError {
     #[error("Client error: {0}")]
     Client(#[from] reqwest::Error),
 
-    /// A spawned process returned an error or an unsuccessful result.
-    #[error("Process failed: {0}")]
-    Process(String),
-
     /// A failing HTTP response.
     #[error("Response error: {0}")]
     Response(String),
@@ -81,3 +77,28 @@ pub enum FatalError {
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct ClientCreationError(#[from] reqwest::Error);
+
+/// Error in retrieving a commit or its info using `git ls-remote`.
+#[derive(Debug, Error)]
+pub enum CommitHashError {
+    /// I/O error while spawning the process.
+    #[error("I/O error in `git ls-remote`: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Unexpected exit status.
+    #[error("Unexpected `git ls-remote` exit status: {0}")]
+    UnexpectedStatus(String),
+
+    /// Unexpected output format.
+    #[error(
+        "Unexpected `git ls-remote` output format. Repo: {repo_url}; Branch: {branch}; Stdout: {stdout}"
+    )]
+    UnexpectedOutput {
+        /// The process output text.
+        stdout: String,
+        /// The relevant git repository URL.
+        repo_url: String,
+        /// The relevant git branch.
+        branch: String,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,46 +1,17 @@
 //! Error type definitions and implementations.
 
-use std::time::SystemTimeError;
-
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
 use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
-
-use crate::events::BranchUpdateEvent;
 
 /// Consolidates every application error into a single type.
 #[derive(Debug, Error)]
 pub enum AppError {
-    /// Error encountered during an I/O operation.
-    #[error("I/O Error: {0}")]
-    Io(#[from] std::io::Error),
-
     /// Error occurred while executing database query or connection.
     #[error("SQLx Error: {0}")]
     Sqlx(#[from] sqlx::Error),
-
-    /// Failure retrieving or computing system time.
-    #[error("System Time Error: {0}")]
-    SystemTime(#[from] SystemTimeError),
-
-    /// Error during JWT token generation or validation.
-    #[error("JWT Error: {0}")]
-    Jwt(#[from] jsonwebtoken::errors::Error),
-
-    /// Failed to send update event to the trigger engine channel.
-    #[error("Channel send error: {0}")]
-    ChannelSend(#[from] SendError<BranchUpdateEvent>),
-
-    /// Error encountered during HTTP request to GitHub API.
-    #[error("Client error: {0}")]
-    Client(#[from] reqwest::Error),
-
-    /// A failing HTTP response.
-    #[error("Response error: {0}")]
-    Response(String),
 }
 
 impl IntoResponse for AppError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,5 +79,5 @@ pub enum FatalError {
 ///
 /// The server cannot trigger workflows.
 #[derive(Debug, Error)]
-#[error("HTTP Client creation: {0}")]
+#[error(transparent)]
 pub struct ClientCreationError(#[from] reqwest::Error);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,6 @@
 //! Axum route handlers.
 
-use crate::error::AppError;
+use crate::error::HandlerError;
 use crate::model::{Branch, CreateBranch, CreateSubscriber, Subscriber};
 use crate::state::AppState;
 use axum::{Json, extract::State};
@@ -10,7 +10,7 @@ use tracing::info;
 pub async fn create_branch(
     State(state): State<AppState>,
     Json(payload): Json<CreateBranch>,
-) -> Result<Json<Branch>, AppError> {
+) -> Result<Json<Branch>, HandlerError> {
     let branch = sqlx::query_as::<_, Branch>(
         "INSERT INTO branches (repo_url, name) VALUES (?, ?) RETURNING *",
     )
@@ -28,7 +28,7 @@ pub async fn create_branch(
 pub async fn create_subscriber(
     State(state): State<AppState>,
     Json(payload): Json<CreateSubscriber>,
-) -> Result<Json<Subscriber>, AppError> {
+) -> Result<Json<Subscriber>, HandlerError> {
     let mut transaction = state.db_pool.begin().await?;
     let branch_id = get_or_insert_branch_id(&mut transaction, &payload).await?;
     let subscriber = sqlx::query_as::<_, Subscriber>(
@@ -53,7 +53,7 @@ pub async fn create_subscriber(
 async fn get_or_insert_branch_id(
     transaction: &mut sqlx::SqliteConnection,
     payload: &CreateSubscriber,
-) -> Result<i64, AppError> {
+) -> Result<i64, HandlerError> {
     let branch_id_opt =
         sqlx::query_scalar::<_, i64>("SELECT id FROM branches WHERE repo_url = ? AND name = ?")
             .bind(&payload.source_repo_url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::{
-    error::FatalError,
+    error::{ClientCreationError, FatalError},
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
     state::AppState,
@@ -66,7 +66,7 @@ async fn run_app() -> Result<(), FatalError> {
 }
 
 /// Creates a new HTTP client.
-pub fn build_http_client() -> Result<Client, FatalError> {
+pub fn build_http_client() -> Result<Client, ClientCreationError> {
     const USER_AGENT: &str = "nilirad-relay-server";
 
     let client = Client::builder().user_agent(USER_AGENT).build()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::{
-    error::AppError,
+    error::FatalError,
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
     state::AppState,
@@ -29,7 +29,7 @@ async fn main() {
 }
 
 /// Runs the server, delegating errors to the caller.
-async fn run_app() -> Result<(), AppError> {
+async fn run_app() -> Result<(), FatalError> {
     const BRANCH_UPDATE_EVENT_BUFFER_SIZE: usize = 64;
 
     tracing_subscriber::fmt::init();
@@ -49,9 +49,13 @@ async fn run_app() -> Result<(), AppError> {
         .route("/branches", post(create_branch))
         .route("/subscribers", post(create_subscriber))
         .with_state(state);
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
+        .await
+        .map_err(FatalError::TcpBinding)?;
     println!("Server listening on http://0.0.0.0:3000");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .await
+        .map_err(FatalError::Serve)?;
 
     token.cancel();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use axum::{
     Router,
     routing::{get, post},
 };
+use reqwest::Client;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
@@ -39,10 +40,12 @@ async fn run_app() -> Result<(), FatalError> {
         db_pool: pool.clone(),
     };
 
+    let http_client = build_http_client()?;
+
     let token = CancellationToken::new();
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(pool.clone(), token.clone(), tx);
-    trigger::start_trigger_engine(pool, token.clone(), rx);
+    trigger::start_trigger_engine(pool, http_client, token.clone(), rx);
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))
@@ -60,4 +63,13 @@ async fn run_app() -> Result<(), FatalError> {
     token.cancel();
 
     Ok(())
+}
+
+/// Creates a new HTTP client.
+pub fn build_http_client() -> Result<Client, FatalError> {
+    const USER_AGENT: &str = "nilirad-relay-server";
+
+    let client = Client::builder().user_agent(USER_AGENT).build()?;
+
+    Ok(client)
 }

--- a/src/polling/branch.rs
+++ b/src/polling/branch.rs
@@ -1,6 +1,6 @@
 //! Utilities for checking whether a branch has updated.
 
-use crate::{error::AppError, model::Branch, polling::git::get_latest_hash};
+use crate::{error::CommitHashError, model::Branch, polling::git::get_latest_hash};
 
 /// Enables comparison between a git branch row, and the newly fetched branch.
 pub(super) struct BranchInfo {
@@ -13,7 +13,7 @@ pub(super) struct BranchInfo {
 
 impl BranchInfo {
     /// Creates a [`BranchInfo`] given a branch row.
-    pub async fn new(branch: Branch) -> Result<BranchInfo, AppError> {
+    pub async fn new(branch: Branch) -> Result<BranchInfo, CommitHashError> {
         let latest_hash = get_latest_hash(branch.repo_url.clone(), branch.name.clone()).await?;
         Ok(BranchInfo {
             branch,

--- a/src/polling/db.rs
+++ b/src/polling/db.rs
@@ -2,20 +2,14 @@
 
 use futures::{StreamExt, stream};
 use sqlx::SqlitePool;
-use tracing::{info, warn};
+use tracing::warn;
 
-use crate::{
-    error::{AppError, CommitHashError},
-    events::BranchUpdateEvent,
-    model::Branch,
-    polling::branch::BranchInfo,
-};
-use tokio::sync::mpsc::Sender;
+use crate::{error::CommitHashError, model::Branch, polling::branch::BranchInfo};
 
 /// Gathers stored branches that need to be updated.
 pub(super) async fn gather_updated_branches(
     pool: &SqlitePool,
-) -> Result<Vec<BranchInfo>, AppError> {
+) -> Result<Vec<BranchInfo>, sqlx::Error> {
     // TODO: Make buffer size configurable.
     const BUFFER_SIZE: usize = 3;
 
@@ -41,38 +35,24 @@ pub(super) async fn gather_updated_branches(
 /// Updates branch rows with the latest hash.
 pub(super) async fn update_branches_table(
     pool: &SqlitePool,
-    branch_infos: Vec<BranchInfo>,
-    tx: &Sender<BranchUpdateEvent>,
-) -> Result<(), AppError> {
+    branch_infos: &[BranchInfo],
+) -> Result<(), sqlx::Error> {
     // Prevents opening a transaction for nothing.
     if branch_infos.is_empty() {
         return Ok(());
     }
 
     let mut transaction = pool.begin().await?;
-    for branch_info in &branch_infos {
+    for branch_info in branch_infos {
         write_db(branch_info, &mut *transaction).await?;
     }
     transaction.commit().await?;
-
-    for outcome in branch_infos {
-        info!(
-            "New commit detected for branch {}. Hash: {}",
-            outcome.branch.name, outcome.latest_hash
-        );
-
-        let event = BranchUpdateEvent {
-            branch_id: outcome.branch.id,
-            new_hash: outcome.latest_hash.clone(),
-        };
-        tx.send(event).await?;
-    }
 
     Ok(())
 }
 
 /// Collects all branch rows.
-async fn collect_branches(pool: &SqlitePool) -> Result<Vec<Branch>, AppError> {
+async fn collect_branches(pool: &SqlitePool) -> Result<Vec<Branch>, sqlx::Error> {
     let branches = sqlx::query_as::<_, Branch>("SELECT * FROM branches")
         .fetch_all(pool)
         .await?;
@@ -81,7 +61,7 @@ async fn collect_branches(pool: &SqlitePool) -> Result<Vec<Branch>, AppError> {
 }
 
 /// Writes the updated branch hash to the row.
-async fn write_db<'e, E>(branch_info: &BranchInfo, executor: E) -> Result<(), AppError>
+async fn write_db<'e, E>(branch_info: &BranchInfo, executor: E) -> Result<(), sqlx::Error>
 where
     E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
 {

--- a/src/polling/db.rs
+++ b/src/polling/db.rs
@@ -5,7 +5,10 @@ use sqlx::SqlitePool;
 use tracing::{info, warn};
 
 use crate::{
-    error::AppError, events::BranchUpdateEvent, model::Branch, polling::branch::BranchInfo,
+    error::{AppError, CommitHashError},
+    events::BranchUpdateEvent,
+    model::Branch,
+    polling::branch::BranchInfo,
 };
 use tokio::sync::mpsc::Sender;
 
@@ -19,12 +22,12 @@ pub(super) async fn gather_updated_branches(
     let branch_results = stream::iter(collect_branches(pool).await?)
         .map(BranchInfo::new)
         .buffer_unordered(BUFFER_SIZE)
-        .collect::<Vec<Result<BranchInfo, AppError>>>()
+        .collect::<Vec<Result<BranchInfo, CommitHashError>>>()
         .await;
 
     let errs = branch_results.iter().filter_map(|res| res.as_ref().err());
     for e in errs {
-        warn!("Error fetching branch update: {e}");
+        warn!("{e}");
     }
 
     let updated_branches = branch_results

--- a/src/polling/error.rs
+++ b/src/polling/error.rs
@@ -2,22 +2,30 @@
 
 use std::time::Duration;
 
+use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, warn};
 
-use crate::error::AppError;
+use crate::events::BranchUpdateEvent;
+
+/// An error that interrupted a polling loop iteration.
+#[derive(Debug, Error)]
+pub enum PollingError {
+    /// Could not read or write database.
+    #[error("Database operation failed: {0}")]
+    DatabaseOperation(#[from] sqlx::Error),
+
+    /// Could not send a [`BranchUpdateEvent`].
+    #[error("Could not send branch update event: {0}")]
+    Channel(#[from] SendError<BranchUpdateEvent>),
+}
 
 /// Handles polling engine errors.
-pub(super) async fn handle_polling_error(error: AppError, token: &CancellationToken) {
-    const DEFAULT_ERROR_SLEEP_SECS: u64 = 5 * 60;
-    if let AppError::Sqlx(e) = error {
-        handle_sqlx_error(e, token).await;
-    } else {
-        error!("Unexpected error raised: {error}");
-        tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(DEFAULT_ERROR_SLEEP_SECS)) => {}
-            _ = token.cancelled() => {}
-        }
+pub(super) async fn handle_polling_error(error: PollingError, token: &CancellationToken) {
+    match error {
+        PollingError::DatabaseOperation(e) => handle_sqlx_error(e, token).await,
+        PollingError::Channel(e) => handle_channel_error(e, token).await,
     }
 }
 
@@ -52,5 +60,16 @@ async fn handle_sqlx_error(error: sqlx::Error, token: &CancellationToken) {
             _ = tokio::time::sleep(Duration::from_secs(DB_ERROR_COOLDOWN_SECS)) => {}
             _ = token.cancelled() => {}
         }
+    }
+}
+
+/// Handles an error of type [`PollingError::Channel`].
+async fn handle_channel_error(error: SendError<BranchUpdateEvent>, token: &CancellationToken) {
+    const DEFAULT_ERROR_SLEEP_SECS: u64 = 5 * 60;
+
+    warn!("{error}");
+    tokio::select! {
+        _ = tokio::time::sleep(Duration::from_secs(DEFAULT_ERROR_SLEEP_SECS)) => {}
+        _ = token.cancelled() => {}
     }
 }

--- a/src/polling/git.rs
+++ b/src/polling/git.rs
@@ -1,42 +1,46 @@
 //! Operations to fetch and extract git branch data from remote repositories.
 
-use crate::error::AppError;
+use crate::error::CommitHashError;
 
 /// Returns the latest commit of a branch in a remote git repository.
 ///
 /// Runs the command `git ls-remote`.
-pub(super) async fn get_latest_hash(repo_url: String, branch: String) -> Result<String, AppError> {
+pub(super) async fn get_latest_hash(
+    repo_url: String,
+    branch: String,
+) -> Result<String, CommitHashError> {
     tokio::process::Command::new("git")
         .args(["ls-remote", &repo_url, &branch])
         .output()
         .await
-        .map_err(AppError::from)
+        .map_err(CommitHashError::from)
         .and_then(handle_git_output_result)
         .and_then(|stdout| extract_hash(stdout, repo_url, branch))
 }
 
 /// Analyzes the `git` exit status to handle process output.
-fn handle_git_output_result(output: std::process::Output) -> Result<Vec<u8>, AppError> {
+fn handle_git_output_result(output: std::process::Output) -> Result<Vec<u8>, CommitHashError> {
     if output.status.success() {
         Ok(output.stdout)
     } else {
-        let msg = format!(
-            "Git command failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let io_error = std::io::Error::other(msg);
-        Err(io_error.into())
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        Err(CommitHashError::UnexpectedStatus(stderr))
     }
 }
 
 /// Extracts the commit hash from a `git ls-remote` process stdout.
-fn extract_hash(stdout: Vec<u8>, repo_url: String, branch: String) -> Result<String, AppError> {
+fn extract_hash(
+    stdout: Vec<u8>,
+    repo_url: String,
+    branch: String,
+) -> Result<String, CommitHashError> {
     String::from_utf8_lossy(&stdout)
         .split_whitespace()
         .next()
         .map(|s| s.to_string())
-        .ok_or(AppError::Process(format!(
-            "Could not extract hash using `git ls-remote {repo_url} {branch}.\nstdout:\n{}`",
-            String::from_utf8_lossy(&stdout)
-        )))
+        .ok_or(CommitHashError::UnexpectedOutput {
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            repo_url,
+            branch,
+        })
 }

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -3,16 +3,16 @@
 use std::time::Duration;
 
 use sqlx::SqlitePool;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Sender, error::SendError};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    error::AppError,
     events::BranchUpdateEvent,
     polling::{
+        branch::BranchInfo,
         db::{gather_updated_branches, update_branches_table},
-        error::handle_polling_error,
+        error::{PollingError, handle_polling_error},
     },
 };
 
@@ -45,17 +45,22 @@ async fn polling_loop(pool: SqlitePool, token: CancellationToken, tx: Sender<Bra
 }
 
 /// Orchestrates polling operations.
-async fn poll_branches(pool: &SqlitePool, tx: &Sender<BranchUpdateEvent>) -> Result<(), AppError> {
+async fn poll_branches(
+    pool: &SqlitePool,
+    tx: &Sender<BranchUpdateEvent>,
+) -> Result<(), PollingError> {
     let updated_branches = gather_updated_branches(pool).await?;
-    update_branches_table(pool, updated_branches, tx).await?;
+    update_branches_table(pool, &updated_branches).await?;
+    send_branch_update_events(&updated_branches, tx).await?;
 
     Ok(())
 }
 
 /// Handles polling results and puts the task to sleep.
-async fn followup_poll(res: Result<(), AppError>, token: &CancellationToken) {
+async fn followup_poll(res: Result<(), PollingError>, token: &CancellationToken) {
     // TODO: Make polling cooldown configurable.
     const SLEEP_SECS: u64 = 5 * 60;
+
     match res {
         Ok(_) => tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(SLEEP_SECS)) => {}
@@ -63,4 +68,25 @@ async fn followup_poll(res: Result<(), AppError>, token: &CancellationToken) {
         },
         Err(e) => handle_polling_error(e, token).await,
     }
+}
+
+/// Sends [`BranchUpdateEvent`]s on a Tokio MPSC channel.
+async fn send_branch_update_events(
+    updated_branches: &[BranchInfo],
+    tx: &Sender<BranchUpdateEvent>,
+) -> Result<(), SendError<BranchUpdateEvent>> {
+    for branch_info in updated_branches {
+        info!(
+            "New commit detected for branch {}. Hash: {}",
+            branch_info.branch.name, branch_info.latest_hash
+        );
+
+        let event = BranchUpdateEvent {
+            branch_id: branch_info.branch.id,
+            new_hash: branch_info.latest_hash.clone(),
+        };
+        tx.send(event).await?;
+    }
+
+    Ok(())
 }

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::{error::AppError, model::Subscriber};
+use crate::{model::Subscriber, trigger::error::AuthError};
 
 /// Payload that GitHub expects in the JWT.
 ///
@@ -31,7 +31,7 @@ struct GitHubClaims {
 ///
 /// <!-- LINKS -->
 /// [jwt_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
-pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String, AppError> {
+pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String, AuthError> {
     // TODO: Check if you should use Tokio API.
     let pem = std::fs::read(pem_path)?;
 
@@ -64,7 +64,7 @@ pub(super) async fn request_iat(
     http_client: &Client,
     jwt: &str,
     sub: &Subscriber,
-) -> Result<String, AppError> {
+) -> Result<String, AuthError> {
     #[derive(serde::Deserialize)]
     struct IatResponse {
         token: String,
@@ -87,10 +87,9 @@ pub(super) async fn request_iat(
         info!("IAT received for subscriber {}", sub.target_repo);
         Ok(response_json.token)
     } else {
-        Err(AppError::Response(format!(
-            "Unexpected status {}: {}",
-            response.status(),
-            response.text().await?
-        )))
+        Err(AuthError::Response {
+            status: response.status(),
+            text: response.text().await?,
+        })
     }
 }

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -5,7 +5,10 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::{model::Subscriber, trigger::error::AuthError};
+use crate::{
+    model::Subscriber,
+    trigger::error::{AuthError, RequestError},
+};
 
 /// Payload that GitHub expects in the JWT.
 ///
@@ -87,9 +90,9 @@ pub(super) async fn request_iat(
         info!("IAT received for subscriber {}", sub.target_repo);
         Ok(response_json.token)
     } else {
-        Err(AuthError::Response {
+        Err(AuthError::Server(RequestError::Response {
             status: response.status(),
             text: response.text().await?,
-        })
+        }))
     }
 }

--- a/src/trigger/error.rs
+++ b/src/trigger/error.rs
@@ -13,18 +13,15 @@ pub enum WorkflowTriggerError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
-    /// Missing response from API service.
-    #[error("HTTP request failed: {0}")]
-    Request(#[from] reqwest::Error),
+    /// API service error.
+    #[error(transparent)]
+    Api(#[from] RequestError),
+}
 
-    /// Bad response from API service.
-    #[error("Unexpected HTTP response ({status}): {text}")]
-    Response {
-        /// The HTTP status code of the response.
-        status: reqwest::StatusCode,
-        /// The full text of the HTTP response.
-        text: String,
-    },
+impl From<reqwest::Error> for WorkflowTriggerError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Api(RequestError::Request(e))
+    }
 }
 
 /// Authentication errors.
@@ -42,11 +39,25 @@ pub enum AuthError {
     #[error("JWT generation failed: {0}")]
     Jwt(#[from] jsonwebtoken::errors::Error),
 
-    /// Missing response from authentication server.
+    /// Authentication server error.
+    #[error(transparent)]
+    Server(#[from] RequestError),
+}
+
+impl From<reqwest::Error> for AuthError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Server(RequestError::Request(e))
+    }
+}
+
+/// An error while performing an HTTP request.
+#[derive(Debug, Error)]
+pub enum RequestError {
+    /// Missing response from API service.
     #[error("HTTP request failed: {0}")]
     Request(#[from] reqwest::Error),
 
-    /// Bad response from authentication server.
+    /// Bad response from API service.
     #[error("Unexpected HTTP response ({status}): {text}")]
     Response {
         /// The HTTP status code of the response.

--- a/src/trigger/error.rs
+++ b/src/trigger/error.rs
@@ -1,0 +1,57 @@
+//! Error type definitions.
+
+use thiserror::Error;
+
+/// An error that interrupted a workflow trigger loop iteration.
+#[derive(Debug, Error)]
+pub enum WorkflowTriggerError {
+    /// Error during JWT or IAT authentication.
+    #[error("Authentication error: {0}")]
+    Auth(#[from] AuthError),
+
+    /// Database error.
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    /// Missing response from API service.
+    #[error("HTTP request failed: {0}")]
+    Request(#[from] reqwest::Error),
+
+    /// Bad response from API service.
+    #[error("Unexpected HTTP response ({status}): {text}")]
+    Response {
+        /// The HTTP status code of the response.
+        status: reqwest::StatusCode,
+        /// The full text of the HTTP response.
+        text: String,
+    },
+}
+
+/// Authentication errors.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// Failed to read PEM file.
+    #[error("Could not read PEM file: {0}")]
+    PemFile(#[from] std::io::Error),
+
+    /// An error with time APIs.
+    #[error("System time: {0}")]
+    Time(#[from] std::time::SystemTimeError),
+
+    /// Error while generating a JWT.
+    #[error("JWT generation failed: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+
+    /// Missing response from authentication server.
+    #[error("HTTP request failed: {0}")]
+    Request(#[from] reqwest::Error),
+
+    /// Bad response from authentication server.
+    #[error("Unexpected HTTP response ({status}): {text}")]
+    Response {
+        /// The HTTP status code of the response.
+        status: reqwest::StatusCode,
+        /// The full text of the HTTP response.
+        text: String,
+    },
+}

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     model::Subscriber,
     trigger::{
         auth::{generate_gh_jwt, request_iat},
-        error::WorkflowTriggerError,
+        error::{RequestError, WorkflowTriggerError},
     },
 };
 
@@ -155,9 +155,9 @@ async fn send_repository_dispatch(
         );
         Ok(())
     } else {
-        Err(WorkflowTriggerError::Response {
+        Err(WorkflowTriggerError::Api(RequestError::Response {
             status: response.status(),
             text: response.text().await?,
-        })
+        }))
     }
 }

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -9,13 +9,16 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use crate::{
-    error::AppError,
     events::BranchUpdateEvent,
     model::Subscriber,
-    trigger::auth::{generate_gh_jwt, request_iat},
+    trigger::{
+        auth::{generate_gh_jwt, request_iat},
+        error::WorkflowTriggerError,
+    },
 };
 
 mod auth;
+mod error;
 
 /// Spawns an asynchronous task to trigger repository workflows.
 ///
@@ -63,7 +66,7 @@ async fn dispatch_events(
     pool: &SqlitePool,
     http_client: &Client,
     event: BranchUpdateEvent,
-) -> Result<(), AppError> {
+) -> Result<(), WorkflowTriggerError> {
     info!(
         "Received update event for branch {}: {}",
         event.branch_id, event.new_hash
@@ -91,7 +94,7 @@ async fn dispatch_events(
 async fn get_subscribers(
     pool: &SqlitePool,
     event: &BranchUpdateEvent,
-) -> Result<Vec<Subscriber>, AppError> {
+) -> Result<Vec<Subscriber>, WorkflowTriggerError> {
     let subscribers =
         sqlx::query_as::<_, Subscriber>("SELECT * FROM subscribers WHERE branch_id = ?")
             .bind(event.branch_id)
@@ -108,7 +111,7 @@ async fn notify_subscriber(
     jwt: &str,
     event: &BranchUpdateEvent,
     sub: Subscriber,
-) -> Result<(), AppError> {
+) -> Result<(), WorkflowTriggerError> {
     let iat = request_iat(http_client, jwt, &sub).await?;
     send_repository_dispatch(http_client, &iat, event, &sub).await?;
     Ok(())
@@ -120,7 +123,7 @@ async fn send_repository_dispatch(
     iat: &str,
     event: &BranchUpdateEvent,
     sub: &Subscriber,
-) -> Result<(), AppError> {
+) -> Result<(), WorkflowTriggerError> {
     let api_url = format!(
         "https://api.github.com/repos/{}/dispatches",
         sub.target_repo
@@ -152,10 +155,9 @@ async fn send_repository_dispatch(
         );
         Ok(())
     } else {
-        Err(AppError::Response(format!(
-            "Unexpected status {}: {}",
-            response.status(),
-            response.text().await?
-        )))
+        Err(WorkflowTriggerError::Response {
+            status: response.status(),
+            text: response.text().await?,
+        })
     }
 }

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -23,10 +23,10 @@ mod auth;
 /// triggering a workflow for each event it receives.
 pub fn start_trigger_engine(
     pool: SqlitePool,
+    http_client: Client,
     token: CancellationToken,
     rx: Receiver<BranchUpdateEvent>,
 ) {
-    let http_client = build_http_client();
     tokio::spawn(async move {
         info!("Trigger engine started");
         trigger_loop(pool, http_client, token, rx).await;
@@ -158,14 +158,4 @@ async fn send_repository_dispatch(
             response.text().await?
         )))
     }
-}
-
-/// Creates a new HTTP client.
-fn build_http_client() -> Client {
-    const USER_AGENT: &str = "nilirad-relay-server";
-
-    Client::builder()
-        .user_agent(USER_AGENT)
-        .build()
-        .expect("Failed to build HTTP client")
 }


### PR DESCRIPTION
- Closes #17 

Decomposes the monolithic `AppError` into smaller, domain-specific error types. I also downgraded the HTTP client creation panic to a `FatalError`, creating it in the setup phase and exiting early on failure.