### PR TITLE
Treat missing environment variables as `FatalErrors`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,10 @@ pub enum FatalError {
     #[allow(clippy::missing_docs_in_private_items)]
     #[error("HTTP Client creation: {0}")]
     ClientCreation(#[from] ClientCreationError),
+
+    /// Environment variable not set.
+    #[error("Environment variable '{0}' not set")]
+    EnvVarNotSet(String),
 }
 
 /// HTTP Client creation failed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,11 +48,19 @@ async fn run_app() -> Result<(), FatalError> {
     };
 
     let http_client = build_http_client()?;
+    let (gh_client_id, gh_app_key_path) = read_environment_variables()?;
 
     let token = CancellationToken::new();
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(pool.clone(), token.clone(), tx);
-    trigger::start_trigger_engine(pool, http_client, token.clone(), rx);
+    trigger::start_trigger_engine(
+        pool,
+        http_client,
+        token.clone(),
+        rx,
+        gh_client_id,
+        gh_app_key_path,
+    );
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))
@@ -79,4 +87,14 @@ pub fn build_http_client() -> Result<Client, ClientCreationError> {
     let client = Client::builder().user_agent(USER_AGENT).build()?;
 
     Ok(client)
+}
+
+/// Reads the required environment variables.
+pub fn read_environment_variables() -> Result<(String, String), FatalError> {
+    let client_id = std::env::var("GH_CLIENT_ID")
+        .map_err(|_| FatalError::EnvVarNotSet("GH_CLIENT_ID".to_string()))?;
+    let pem_path = std::env::var("GH_APP_KEY_PATH")
+        .map_err(|_| FatalError::EnvVarNotSet("GH_APP_KEY_PATH".to_string()))?;
+
+    Ok((client_id, pem_path))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,12 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, clippy::missing_docs_in_private_items)]
+#![warn(
+    clippy::panic,
+    clippy::expect_used,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
 
 use axum::{
     Router,

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -1,7 +1,5 @@
 //! Asynchronous task to trigger remote repository workflows.
 
-use std::env;
-
 use reqwest::Client;
 use sqlx::SqlitePool;
 use tokio::sync::mpsc::Receiver;
@@ -29,10 +27,12 @@ pub fn start_trigger_engine(
     http_client: Client,
     token: CancellationToken,
     rx: Receiver<BranchUpdateEvent>,
+    client_id: String,
+    pem_path: String,
 ) {
     tokio::spawn(async move {
         info!("Trigger engine started");
-        trigger_loop(pool, http_client, token, rx).await;
+        trigger_loop(pool, http_client, token, rx, client_id, pem_path).await;
     });
 }
 
@@ -42,10 +42,12 @@ async fn trigger_loop(
     http_client: Client,
     token: CancellationToken,
     mut rx: Receiver<BranchUpdateEvent>,
+    client_id: String,
+    pem_path: String,
 ) {
     loop {
         tokio::select! {
-            Some(event) = rx.recv() => handle_branch_update(&pool, &http_client, event).await,
+            Some(event) = rx.recv() => handle_branch_update(&pool, &http_client, event, &client_id, &pem_path).await,
             _ = token.cancelled() => break,
         }
     }
@@ -53,8 +55,14 @@ async fn trigger_loop(
 }
 
 /// Handles a [`BranchUpdateEvent`], handling any possible error.
-async fn handle_branch_update(pool: &SqlitePool, http_client: &Client, event: BranchUpdateEvent) {
-    let result = dispatch_events(pool, http_client, event).await;
+async fn handle_branch_update(
+    pool: &SqlitePool,
+    http_client: &Client,
+    event: BranchUpdateEvent,
+    client_id: &str,
+    pem_path: &str,
+) {
+    let result = dispatch_events(pool, http_client, event, client_id, pem_path).await;
 
     if let Err(e) = result {
         error!("{e}");
@@ -66,6 +74,8 @@ async fn dispatch_events(
     pool: &SqlitePool,
     http_client: &Client,
     event: BranchUpdateEvent,
+    client_id: &str,
+    pem_path: &str,
 ) -> Result<(), WorkflowTriggerError> {
     info!(
         "Received update event for branch {}: {}",
@@ -74,11 +84,7 @@ async fn dispatch_events(
 
     let subscribers = get_subscribers(pool, &event).await?;
 
-    let client_id =
-        env::var("GH_CLIENT_ID").expect("Environment variable `GH_CLIENT_ID` must be set");
-    let pem_path =
-        env::var("GH_APP_KEY_PATH").expect("Environment variable `GH_APP_KEY_PATH` must be set");
-    let jwt = generate_gh_jwt(&client_id, &pem_path)?;
+    let jwt = generate_gh_jwt(client_id, pem_path)?;
 
     for sub in subscribers {
         let result = notify_subscriber(http_client, &jwt, &event, sub).await;


### PR DESCRIPTION
- Closes #30

Environment variables are now checked early, and the relative panicking pathways have been removed. I also Set some Clippy lints to avoid using common panicking operations.