### PR TITLE
Reduce function arguments to max `4`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 5

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold = 5
+too-many-arguments-threshold = 4

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,13 @@
+//! Shared context for background engines.
+
+use sqlx::SqlitePool;
+use tokio_util::sync::CancellationToken;
+
+/// Shared dependencies across background engines.
+#[derive(Clone, Debug)]
+pub struct SharedContext {
+    /// SQLx connection pool for the SQLite database.
+    pub db_pool: SqlitePool,
+    /// Token to signal task cancellation.
+    pub token: CancellationToken,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::{
+    context::SharedContext,
     error::{ClientCreationError, FatalError},
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
@@ -24,6 +25,7 @@ use crate::{
     trigger::get_auth_credentials,
 };
 
+mod context;
 mod error;
 mod events;
 mod handler;
@@ -52,9 +54,13 @@ async fn run_app() -> Result<(), FatalError> {
     let creds = get_auth_credentials()?;
 
     let token = CancellationToken::new();
+    let ctx = SharedContext {
+        db_pool: pool.clone(),
+        token: token.clone(),
+    };
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
-    polling::start_polling_engine(pool.clone(), token.clone(), tx);
-    trigger::start_trigger_engine(pool, http_client, token.clone(), rx, creds);
+    polling::start_polling_engine(ctx.clone(), tx);
+    trigger::start_trigger_engine(ctx, http_client, rx, creds);
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use crate::{
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
     state::AppState,
+    trigger::get_auth_credentials,
 };
 
 mod error;
@@ -48,19 +49,12 @@ async fn run_app() -> Result<(), FatalError> {
     };
 
     let http_client = build_http_client()?;
-    let (gh_client_id, gh_app_key_path) = read_environment_variables()?;
+    let creds = get_auth_credentials()?;
 
     let token = CancellationToken::new();
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(pool.clone(), token.clone(), tx);
-    trigger::start_trigger_engine(
-        pool,
-        http_client,
-        token.clone(),
-        rx,
-        gh_client_id,
-        gh_app_key_path,
-    );
+    trigger::start_trigger_engine(pool, http_client, token.clone(), rx, creds);
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))
@@ -87,14 +81,4 @@ pub fn build_http_client() -> Result<Client, ClientCreationError> {
     let client = Client::builder().user_agent(USER_AGENT).build()?;
 
     Ok(client)
-}
-
-/// Reads the required environment variables.
-pub fn read_environment_variables() -> Result<(String, String), FatalError> {
-    let client_id = std::env::var("GH_CLIENT_ID")
-        .map_err(|_| FatalError::EnvVarNotSet("GH_CLIENT_ID".to_string()))?;
-    let pem_path = std::env::var("GH_APP_KEY_PATH")
-        .map_err(|_| FatalError::EnvVarNotSet("GH_APP_KEY_PATH".to_string()))?;
-
-    Ok((client_id, pem_path))
 }

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -8,6 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
+    context::SharedContext,
     events::BranchUpdateEvent,
     polling::{
         branch::BranchInfo,
@@ -22,23 +23,19 @@ mod error;
 mod git;
 
 /// Spawns an asynchronous task to periodically poll git branches for updates.
-pub fn start_polling_engine(
-    pool: SqlitePool,
-    token: CancellationToken,
-    tx: Sender<BranchUpdateEvent>,
-) {
+pub fn start_polling_engine(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
     tokio::spawn(async move {
         info!("Polling engine started");
-        polling_loop(pool, token, tx).await;
+        polling_loop(ctx, tx).await;
     });
 }
 
 /// Controls whether to shut down the polling engine or run a polling cycle.
-async fn polling_loop(pool: SqlitePool, token: CancellationToken, tx: Sender<BranchUpdateEvent>) {
+async fn polling_loop(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
     loop {
         tokio::select! {
-            res = poll_branches(&pool, &tx) => {followup_poll(res, &token).await}
-            _ = token.cancelled() => break,
+            res = poll_branches(&ctx.db_pool, &tx) => {followup_poll(res, &ctx.token).await}
+            _ = ctx.token.cancelled() => break,
         }
     }
     info!("Gracefully shutting down polling engine");

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -6,9 +6,19 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::{
+    error::FatalError,
     model::Subscriber,
     trigger::error::{AuthError, RequestError},
 };
+
+/// Credentials required for authentication.
+#[derive(Debug, Clone)]
+pub struct AuthCredentials {
+    /// GitHub App's Client ID.
+    pub client_id: String,
+    /// Path to the GitHub App's private key.
+    pub pem_path: String,
+}
 
 /// Payload that GitHub expects in the JWT.
 ///
@@ -28,15 +38,28 @@ struct GitHubClaims {
     iss: String,
 }
 
+/// Reads the environment variables for authentication.
+pub fn get_auth_credentials() -> Result<AuthCredentials, FatalError> {
+    let client_id = std::env::var("GH_CLIENT_ID")
+        .map_err(|_| FatalError::EnvVarNotSet("GH_CLIENT_ID".to_string()))?;
+    let pem_path = std::env::var("GH_APP_KEY_PATH")
+        .map_err(|_| FatalError::EnvVarNotSet("GH_APP_KEY_PATH".to_string()))?;
+
+    Ok(AuthCredentials {
+        client_id,
+        pem_path,
+    })
+}
+
 /// Generates a JWT to authenticate access to the GitHub App.
 ///
 /// Implementation based on [GitHub's documentation][jwt_docs].
 ///
 /// <!-- LINKS -->
 /// [jwt_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
-pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String, AuthError> {
+pub(super) fn generate_gh_jwt(creds: &AuthCredentials) -> Result<String, AuthError> {
     // TODO: Check if you should use Tokio API.
-    let pem = std::fs::read(pem_path)?;
+    let pem = std::fs::read(&creds.pem_path)?;
 
     const CLOCK_DRIFT_BUFFER_SECS: u64 = 60;
     const TOKEN_VALIDITY_SECS: u64 = 5 * 60;
@@ -46,7 +69,7 @@ pub(super) fn generate_gh_jwt(client_id: &str, pem_path: &str) -> Result<String,
     let claims = GitHubClaims {
         iat: now - CLOCK_DRIFT_BUFFER_SECS,
         exp: now + TOKEN_VALIDITY_SECS,
-        iss: client_id.to_string(),
+        iss: creds.client_id.to_string(),
     };
 
     let header = Header::new(Algorithm::RS256);

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -15,6 +15,8 @@ use crate::{
     },
 };
 
+pub use auth::*;
+
 mod auth;
 mod error;
 
@@ -27,12 +29,11 @@ pub fn start_trigger_engine(
     http_client: Client,
     token: CancellationToken,
     rx: Receiver<BranchUpdateEvent>,
-    client_id: String,
-    pem_path: String,
+    creds: AuthCredentials,
 ) {
     tokio::spawn(async move {
         info!("Trigger engine started");
-        trigger_loop(pool, http_client, token, rx, client_id, pem_path).await;
+        trigger_loop(pool, http_client, token, rx, creds).await;
     });
 }
 
@@ -42,12 +43,11 @@ async fn trigger_loop(
     http_client: Client,
     token: CancellationToken,
     mut rx: Receiver<BranchUpdateEvent>,
-    client_id: String,
-    pem_path: String,
+    creds: AuthCredentials,
 ) {
     loop {
         tokio::select! {
-            Some(event) = rx.recv() => handle_branch_update(&pool, &http_client, event, &client_id, &pem_path).await,
+            Some(event) = rx.recv() => handle_branch_update(&pool, &http_client, event, &creds).await,
             _ = token.cancelled() => break,
         }
     }
@@ -59,10 +59,9 @@ async fn handle_branch_update(
     pool: &SqlitePool,
     http_client: &Client,
     event: BranchUpdateEvent,
-    client_id: &str,
-    pem_path: &str,
+    creds: &AuthCredentials,
 ) {
-    let result = dispatch_events(pool, http_client, event, client_id, pem_path).await;
+    let result = dispatch_events(pool, http_client, event, creds).await;
 
     if let Err(e) = result {
         error!("{e}");
@@ -74,8 +73,7 @@ async fn dispatch_events(
     pool: &SqlitePool,
     http_client: &Client,
     event: BranchUpdateEvent,
-    client_id: &str,
-    pem_path: &str,
+    creds: &AuthCredentials,
 ) -> Result<(), WorkflowTriggerError> {
     info!(
         "Received update event for branch {}: {}",
@@ -84,7 +82,7 @@ async fn dispatch_events(
 
     let subscribers = get_subscribers(pool, &event).await?;
 
-    let jwt = generate_gh_jwt(client_id, pem_path)?;
+    let jwt = generate_gh_jwt(creds)?;
 
     for sub in subscribers {
         let result = notify_subscriber(http_client, &jwt, &event, sub).await;

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -3,10 +3,10 @@
 use reqwest::Client;
 use sqlx::SqlitePool;
 use tokio::sync::mpsc::Receiver;
-use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use crate::{
+    context::SharedContext,
     events::BranchUpdateEvent,
     model::Subscriber,
     trigger::{
@@ -25,30 +25,28 @@ mod error;
 /// The spawned task will listen to [`BranchUpdateEvent`]s,
 /// triggering a workflow for each event it receives.
 pub fn start_trigger_engine(
-    pool: SqlitePool,
+    ctx: SharedContext,
     http_client: Client,
-    token: CancellationToken,
     rx: Receiver<BranchUpdateEvent>,
     creds: AuthCredentials,
 ) {
     tokio::spawn(async move {
         info!("Trigger engine started");
-        trigger_loop(pool, http_client, token, rx, creds).await;
+        trigger_loop(ctx, http_client, rx, creds).await;
     });
 }
 
 /// Controls whether to shut down the trigger engine or process a [`BranchUpdateEvent`].
 async fn trigger_loop(
-    pool: SqlitePool,
+    ctx: SharedContext,
     http_client: Client,
-    token: CancellationToken,
     mut rx: Receiver<BranchUpdateEvent>,
     creds: AuthCredentials,
 ) {
     loop {
         tokio::select! {
-            Some(event) = rx.recv() => handle_branch_update(&pool, &http_client, event, &creds).await,
-            _ = token.cancelled() => break,
+            Some(event) = rx.recv() => handle_branch_update(&ctx.db_pool, &http_client, event, &creds).await,
+            _ = ctx.token.cancelled() => break,
         }
     }
     info!("Gracefully shutting down trigger engine");


### PR DESCRIPTION
- Closes #33 

This PR reduces the number of function arguments to a maximum of `4`, setting a hard limit on `clippy.toml`. This was achieved by grouping multiple values into new structs (`AuthCredentials` and `SharedContext`).