### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Tests
-        run: cargo nextest run --locked --all-features --no-tests=pass
+        run: cargo nextest run --locked --all-features
 
       - name: Build
         run: cargo build --locked --release

--- a/.sqlx/query-3384f929d4d57fa34534f53c989b23f9c8d85d232d85af5088fbfa4ffe388346.json
+++ b/.sqlx/query-3384f929d4d57fa34534f53c989b23f9c8d85d232d85af5088fbfa4ffe388346.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO branches (repo_url, name, last_commit_hash) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "3384f929d4d57fa34534f53c989b23f9c8d85d232d85af5088fbfa4ffe388346"
+}

--- a/.sqlx/query-3a286aef5d392d9189cacfe4820ff5aefdc41efd8c5bc6736846ae67334feb08.json
+++ b/.sqlx/query-3a286aef5d392d9189cacfe4820ff5aefdc41efd8c5bc6736846ae67334feb08.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT last_commit_hash FROM branches WHERE id = 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "last_commit_hash",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "3a286aef5d392d9189cacfe4820ff5aefdc41efd8c5bc6736846ae67334feb08"
+}

--- a/.sqlx/query-9a9f2a968273ca0185c7bf114b92879bbeafbe3f11b1b5c2663af0952652483a.json
+++ b/.sqlx/query-9a9f2a968273ca0185c7bf114b92879bbeafbe3f11b1b5c2663af0952652483a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO branches (repo_url, name) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "9a9f2a968273ca0185c7bf114b92879bbeafbe3f11b1b5c2663af0952652483a"
+}

--- a/.sqlx/query-9cef415bd425f08cbc21cc6a2cf8f8385675501d05c0f1b5cef0afda96ef7b83.json
+++ b/.sqlx/query-9cef415bd425f08cbc21cc6a2cf8f8385675501d05c0f1b5cef0afda96ef7b83.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT target_repo FROM subscribers",
+  "describe": {
+    "columns": [
+      {
+        "name": "target_repo",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9cef415bd425f08cbc21cc6a2cf8f8385675501d05c0f1b5cef0afda96ef7b83"
+}

--- a/.sqlx/query-f97b96f7485e2eadc3e119bf231777cc2fe2c21a565a37ec50a123aef89a7e11.json
+++ b/.sqlx/query-f97b96f7485e2eadc3e119bf231777cc2fe2c21a565a37ec50a123aef89a7e11.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO subscribers (branch_id, target_repo, event_type, gh_app_installation_id) VALUES (?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "f97b96f7485e2eadc3e119bf231777cc2fe2c21a565a37ec50a123aef89a7e11"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,12 +599,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1276,12 +1281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1807,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "relay"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "futures",
  "jsonwebtoken",
@@ -1815,7 +1815,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
@@ -1923,19 +1922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2541,19 +2527,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +402,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +588,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -819,6 +853,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1236,6 +1276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1416,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1759,12 +1815,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "validator",
+ "wiremock",
 ]
 
 [[package]]
@@ -1864,6 +1923,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2472,6 +2544,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2707,17 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3261,6 +3357,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3"
 validator = { version = "0.20.0", features = ["derive"] }
 
+[dev-dependencies]
+wiremock = "0.6"
+tempfile = "3.17"
+tokio-test = "0.4"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 axum = { version = "0.8.8", features = ["macros"] }
+async-trait = "0.1"
 futures = "0.3.32"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13.2", features = ["json"] }
@@ -20,7 +21,6 @@ validator = { version = "0.20.0", features = ["derive"] }
 
 [dev-dependencies]
 wiremock = "0.6"
-tempfile = "3.17"
 tokio-test = "0.4"
 
 [profile.release]

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,4 +10,6 @@ pub struct SharedContext {
     pub db_pool: SqlitePool,
     /// Token to signal task cancellation.
     pub token: CancellationToken,
+    /// Base URL for the GitHub API.
+    pub github_api_base_url: String,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,12 @@
 //! Shared context for background engines.
 
+use crate::polling::git::GitFetcher;
 use sqlx::SqlitePool;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 /// Shared dependencies across background engines.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SharedContext {
     /// SQLx connection pool for the SQLite database.
     pub db_pool: SqlitePool,
@@ -12,4 +14,6 @@ pub struct SharedContext {
     pub token: CancellationToken,
     /// Base URL for the GitHub API.
     pub github_api_base_url: String,
+    /// Git fetcher for polling.
+    pub git_fetcher: Arc<dyn GitFetcher>,
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -72,3 +72,47 @@ async fn get_or_insert_branch_id(
         .await
         .map_err(Into::into)
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::panic,
+        clippy::expect_used,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing
+    )]
+
+    use super::*;
+    use crate::model::CreateSubscriber;
+    use crate::state::AppState;
+    use crate::test_utils::create_test_db;
+    use axum::Json;
+    use axum::extract::State;
+
+    #[tokio::test]
+    async fn test_create_subscriber() {
+        let pool = create_test_db().await;
+        let state = AppState { 
+            db_pool: pool.clone(),
+            github_api_base_url: "https://api.github.com".to_string(),
+        };
+        let payload = CreateSubscriber {
+            source_repo_url: "https://github.com/org/repo".to_string(),
+            source_branch_name: "main".to_string(),
+            target_repo: "https://github.com/org/target".to_string(),
+            event_type: "dispatch".to_string(),
+            gh_app_installation_id: 1,
+        };
+
+        let res = create_subscriber(State(state), Json(payload)).await;
+        assert!(res.is_ok());
+
+        // Verify in DB
+        let subscriber = sqlx::query!("SELECT target_repo FROM subscribers")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(subscriber.target_repo, "https://github.com/org/target");
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -93,9 +93,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_subscriber() {
         let pool = create_test_db().await;
-        let state = AppState { 
+        let state = AppState {
             db_pool: pool.clone(),
-            github_api_base_url: "https://api.github.com".to_string(),
         };
         let payload = CreateSubscriber {
             source_repo_url: "https://github.com/org/repo".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ async fn run_app() -> Result<(), FatalError> {
     let ctx = SharedContext {
         db_pool: pool.clone(),
         token: token.clone(),
+        github_api_base_url: "https://api.github.com".to_string(),
     };
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(ctx.clone(), tx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ async fn run_app() -> Result<(), FatalError> {
         db_pool: pool.clone(),
         token: token.clone(),
         github_api_base_url: "https://api.github.com".to_string(),
+        git_fetcher: std::sync::Arc::new(crate::polling::git::MainGitFetcher),
     };
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(ctx.clone(), tx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use crate::{
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
     state::AppState,
-    trigger::{TriggerEngine, get_auth_credentials},
+    trigger::{GitHubAuthenticator, TriggerEngine, get_auth_credentials},
 };
 
 mod context;
@@ -53,7 +53,6 @@ async fn run_app() -> Result<(), FatalError> {
     };
 
     let http_client = build_http_client()?;
-    let creds = get_auth_credentials()?;
 
     let token = CancellationToken::new();
     let ctx = SharedContext {
@@ -65,11 +64,15 @@ async fn run_app() -> Result<(), FatalError> {
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(ctx.clone(), tx);
 
+    let authenticator = Box::new(GitHubAuthenticator {
+        credentials: get_auth_credentials()?,
+        http_client: http_client.clone(),
+    });
     let trigger_engine = TriggerEngine {
         ctx,
         http_client,
         rx,
-        creds,
+        authenticator,
     };
 
     trigger_engine.start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ mod handler;
 mod model;
 mod polling;
 mod state;
+#[cfg(test)]
+mod test_utils;
 mod trigger;
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use crate::{
     events::BranchUpdateEvent,
     handler::{create_branch, create_subscriber},
     state::AppState,
-    trigger::get_auth_credentials,
+    trigger::{TriggerEngine, get_auth_credentials},
 };
 
 mod context;
@@ -64,7 +64,15 @@ async fn run_app() -> Result<(), FatalError> {
     };
     let (tx, rx) = tokio::sync::mpsc::channel::<BranchUpdateEvent>(BRANCH_UPDATE_EVENT_BUFFER_SIZE);
     polling::start_polling_engine(ctx.clone(), tx);
-    trigger::start_trigger_engine(ctx, http_client, rx, creds);
+
+    let trigger_engine = TriggerEngine {
+        ctx,
+        http_client,
+        rx,
+        creds,
+    };
+
+    trigger_engine.start();
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))

--- a/src/polling/branch.rs
+++ b/src/polling/branch.rs
@@ -1,6 +1,6 @@
 //! Utilities for checking whether a branch has updated.
 
-use crate::{error::CommitHashError, model::Branch, polling::git::get_latest_hash};
+use crate::{error::CommitHashError, model::Branch, polling::git::GitFetcher};
 
 /// Enables comparison between a git branch row, and the newly fetched branch.
 pub(super) struct BranchInfo {
@@ -13,8 +13,13 @@ pub(super) struct BranchInfo {
 
 impl BranchInfo {
     /// Creates a [`BranchInfo`] given a branch row.
-    pub async fn new(branch: Branch) -> Result<BranchInfo, CommitHashError> {
-        let latest_hash = get_latest_hash(branch.repo_url.clone(), branch.name.clone()).await?;
+    pub async fn new<F: GitFetcher + ?Sized>(
+        branch: Branch,
+        fetcher: &F,
+    ) -> Result<BranchInfo, CommitHashError> {
+        let latest_hash = fetcher
+            .get_latest_hash(&branch.repo_url, &branch.name)
+            .await?;
         Ok(BranchInfo {
             branch,
             latest_hash,

--- a/src/polling/db.rs
+++ b/src/polling/db.rs
@@ -4,17 +4,22 @@ use futures::{StreamExt, stream};
 use sqlx::SqlitePool;
 use tracing::warn;
 
-use crate::{error::CommitHashError, model::Branch, polling::branch::BranchInfo};
+use crate::{
+    error::CommitHashError,
+    model::Branch,
+    polling::{branch::BranchInfo, git::GitFetcher},
+};
 
 /// Gathers stored branches that need to be updated.
 pub(super) async fn gather_updated_branches(
     pool: &SqlitePool,
+    fetcher: &dyn GitFetcher,
 ) -> Result<Vec<BranchInfo>, sqlx::Error> {
     // TODO: Make buffer size configurable.
     const BUFFER_SIZE: usize = 3;
 
     let branch_results = stream::iter(collect_branches(pool).await?)
-        .map(BranchInfo::new)
+        .map(|b| BranchInfo::new(b, fetcher))
         .buffer_unordered(BUFFER_SIZE)
         .collect::<Vec<Result<BranchInfo, CommitHashError>>>()
         .await;

--- a/src/polling/git.rs
+++ b/src/polling/git.rs
@@ -44,3 +44,71 @@ fn extract_hash(
             branch,
         })
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::panic,
+        clippy::expect_used,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing
+    )]
+
+    use super::*;
+
+    #[test]
+    fn test_extract_hash_success() {
+        let stdout = b"678c4343237127dbadbf1806dd98b2154ffd2ebe\trefs/heads/main\n".to_vec();
+        let repo_url = "https://github.com/Nilirad/relay".to_string();
+        let branch = "main".to_string();
+
+        let result = extract_hash(stdout, repo_url, branch);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "678c4343237127dbadbf1806dd98b2154ffd2ebe");
+    }
+
+    #[test]
+    fn test_extract_hash_empty_output() {
+        let stdout = b"".to_vec();
+        let repo_url = "https://github.com/Nilirad/relay".to_string();
+        let branch = "main".to_string();
+
+        let result = extract_hash(stdout.clone(), repo_url.clone(), branch.clone());
+
+        let Err(CommitHashError::UnexpectedOutput {
+            stdout: err_stdout,
+            repo_url: err_repo_url,
+            branch: err_branch,
+        }) = result
+        else {
+            panic!("Expected UnexpectedOutput error");
+        };
+
+        assert_eq!(err_stdout, String::from_utf8(stdout).unwrap_or_default());
+        assert_eq!(err_repo_url, repo_url);
+        assert_eq!(err_branch, branch);
+    }
+
+    #[test]
+    fn test_extract_hash_whitespace_only() {
+        let stdout = b"   \n\t ".to_vec();
+        let repo_url = "https://github.com/Nilirad/relay".to_string();
+        let branch = "main".to_string();
+
+        let result = extract_hash(stdout.clone(), repo_url.clone(), branch.clone());
+
+        let Err(CommitHashError::UnexpectedOutput {
+            stdout: err_stdout,
+            repo_url: err_repo_url,
+            branch: err_branch,
+        }) = result
+        else {
+            panic!("Expected UnexpectedOutput error");
+        };
+
+        assert_eq!(err_stdout, String::from_utf8(stdout).unwrap_or_default());
+        assert_eq!(err_repo_url, repo_url);
+        assert_eq!(err_branch, branch);
+    }
+}

--- a/src/polling/git.rs
+++ b/src/polling/git.rs
@@ -1,21 +1,36 @@
 //! Operations to fetch and extract git branch data from remote repositories.
 
 use crate::error::CommitHashError;
+use async_trait::async_trait;
 
-/// Returns the latest commit of a branch in a remote git repository.
-///
-/// Runs the command `git ls-remote`.
-pub(super) async fn get_latest_hash(
-    repo_url: String,
-    branch: String,
-) -> Result<String, CommitHashError> {
-    tokio::process::Command::new("git")
-        .args(["ls-remote", &repo_url, &branch])
-        .output()
-        .await
-        .map_err(CommitHashError::from)
-        .and_then(handle_git_output_result)
-        .and_then(|stdout| extract_hash(stdout, repo_url, branch))
+/// Allows running git commands.
+#[async_trait]
+pub trait GitFetcher: Send + Sync {
+    async fn get_latest_hash(
+        &self,
+        repo_url: &str,
+        branch: &str,
+    ) -> Result<String, CommitHashError>;
+}
+
+/// Runs git commands.
+pub struct MainGitFetcher;
+
+#[async_trait]
+impl GitFetcher for MainGitFetcher {
+    async fn get_latest_hash(
+        &self,
+        repo_url: &str,
+        branch: &str,
+    ) -> Result<String, CommitHashError> {
+        tokio::process::Command::new("git")
+            .args(["ls-remote", repo_url, branch])
+            .output()
+            .await
+            .map_err(CommitHashError::from)
+            .and_then(handle_git_output_result)
+            .and_then(|stdout| extract_hash(stdout, repo_url.to_string(), branch.to_string()))
+    }
 }
 
 /// Analyzes the `git` exit status to handle process output.

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -89,25 +89,10 @@ async fn send_branch_update_events(
 
 #[cfg(test)]
 mod tests {
+    use crate::test_utils::MockGitFetcher;
+
     use super::*;
-    use crate::polling::git::GitFetcher;
-    use async_trait::async_trait;
     use std::sync::Arc;
-
-    struct MockGitFetcher {
-        hash: String,
-    }
-
-    #[async_trait]
-    impl GitFetcher for MockGitFetcher {
-        async fn get_latest_hash(
-            &self,
-            _repo: &str,
-            _branch: &str,
-        ) -> Result<String, crate::error::CommitHashError> {
-            Ok(self.hash.clone())
-        }
-    }
 
     #[tokio::test]
     async fn test_poll_branches_updates_db() {

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use sqlx::SqlitePool;
 use tokio::sync::mpsc::{Sender, error::SendError};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -20,7 +19,7 @@ use crate::{
 mod branch;
 mod db;
 mod error;
-mod git;
+pub mod git;
 
 /// Spawns an asynchronous task to periodically poll git branches for updates.
 pub fn start_polling_engine(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
@@ -34,7 +33,7 @@ pub fn start_polling_engine(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
 async fn polling_loop(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
     loop {
         tokio::select! {
-            res = poll_branches(&ctx.db_pool, &tx) => {followup_poll(res, &ctx.token).await}
+            res = poll_branches(&ctx, &tx) => {followup_poll(res, &ctx.token).await}
             _ = ctx.token.cancelled() => break,
         }
     }
@@ -43,11 +42,11 @@ async fn polling_loop(ctx: SharedContext, tx: Sender<BranchUpdateEvent>) {
 
 /// Orchestrates polling operations.
 async fn poll_branches(
-    pool: &SqlitePool,
+    ctx: &SharedContext,
     tx: &Sender<BranchUpdateEvent>,
 ) -> Result<(), PollingError> {
-    let updated_branches = gather_updated_branches(pool).await?;
-    update_branches_table(pool, &updated_branches).await?;
+    let updated_branches = gather_updated_branches(&ctx.db_pool, ctx.git_fetcher.as_ref()).await?;
+    update_branches_table(&ctx.db_pool, &updated_branches).await?;
     send_branch_update_events(&updated_branches, tx).await?;
 
     Ok(())
@@ -86,4 +85,70 @@ async fn send_branch_update_events(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::polling::git::GitFetcher;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct MockGitFetcher {
+        hash: String,
+    }
+
+    #[async_trait]
+    impl GitFetcher for MockGitFetcher {
+        async fn get_latest_hash(
+            &self,
+            _repo: &str,
+            _branch: &str,
+        ) -> Result<String, crate::error::CommitHashError> {
+            Ok(self.hash.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_poll_branches_updates_db() {
+        let pool = crate::test_utils::create_test_db().await;
+
+        // Insert a branch
+        sqlx::query!(
+            "INSERT INTO branches (repo_url, name, last_commit_hash) VALUES (?, ?, ?)",
+            "repo",
+            "main",
+            "old-hash"
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mock_fetcher = Arc::new(MockGitFetcher {
+            hash: "new-hash".to_string(),
+        });
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        let updated_branches = gather_updated_branches(&pool, mock_fetcher.as_ref())
+            .await
+            .unwrap();
+        update_branches_table(&pool, &updated_branches)
+            .await
+            .unwrap();
+        send_branch_update_events(&updated_branches, &tx)
+            .await
+            .unwrap();
+
+        // Verify DB update
+        let branch = sqlx::query!("SELECT last_commit_hash FROM branches WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(branch.last_commit_hash.unwrap(), "new-hash");
+
+        // Verify event sent
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.new_hash, "new-hash");
+    }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,23 @@
+#![allow(
+    clippy::panic,
+    clippy::expect_used,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+
+use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
+
+pub async fn create_test_db() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .expect("Failed to create in-memory database");
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,7 +6,24 @@
     clippy::indexing_slicing
 )]
 
+use crate::polling::git::GitFetcher;
+use async_trait::async_trait;
 use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
+
+pub struct MockGitFetcher {
+    pub hash: String,
+}
+
+#[async_trait]
+impl GitFetcher for MockGitFetcher {
+    async fn get_latest_hash(
+        &self,
+        _repo: &str,
+        _branch: &str,
+    ) -> Result<String, crate::error::CommitHashError> {
+        Ok(self.hash.clone())
+    }
+}
 
 pub async fn create_test_db() -> SqlitePool {
     let pool = SqlitePoolOptions::new()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,7 +6,10 @@
     clippy::indexing_slicing
 )]
 
-use crate::polling::git::GitFetcher;
+use crate::{
+    polling::git::GitFetcher,
+    trigger::{Authenticator, error::AuthError},
+};
 use async_trait::async_trait;
 use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
 
@@ -22,6 +25,20 @@ impl GitFetcher for MockGitFetcher {
         _branch: &str,
     ) -> Result<String, crate::error::CommitHashError> {
         Ok(self.hash.clone())
+    }
+}
+
+pub struct MockAuthenticator {
+    pub iat: String,
+}
+
+#[async_trait]
+impl Authenticator for MockAuthenticator {
+    async fn request_installation_token(
+        &self,
+        _sub: &crate::model::Subscriber,
+    ) -> Result<String, AuthError> {
+        Ok(self.iat.clone())
     }
 }
 

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -88,6 +88,7 @@ pub(super) fn generate_gh_jwt(creds: &AuthCredentials) -> Result<String, AuthErr
 /// [iat_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
 pub(super) async fn request_iat(
     http_client: &Client,
+    api_base_url: &str,
     jwt: &str,
     sub: &Subscriber,
 ) -> Result<String, AuthError> {
@@ -97,8 +98,8 @@ pub(super) async fn request_iat(
     }
 
     let api_url = format!(
-        "https://api.github.com/app/installations/{}/access_tokens",
-        sub.gh_app_installation_id
+        "{}/app/installations/{}/access_tokens",
+        api_base_url, sub.gh_app_installation_id
     );
     let response = http_client
         .post(&api_url)

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -1,5 +1,6 @@
 //! Authentication and authorization to request services.
 
+use async_trait::async_trait;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,32 @@ use crate::{
     model::Subscriber,
     trigger::error::{AuthError, RequestError},
 };
+
+/// Provides authentication functionality.
+#[async_trait]
+pub trait Authenticator {
+    /// Requests a GitHub Installation Access Token.
+    async fn request_installation_token(&self, sub: &Subscriber) -> Result<String, AuthError>;
+}
+
+/// An [`Authenticator`] for GitHub.
+pub struct GitHubAuthenticator {
+    /// The credentials to authenticate to the server.
+    pub credentials: AuthCredentials,
+    /// The HTTP client to make requests to the authentication server.
+    pub http_client: reqwest::Client,
+}
+
+#[async_trait]
+impl Authenticator for GitHubAuthenticator {
+    async fn request_installation_token(
+        &self,
+        subscriber: &Subscriber,
+    ) -> Result<String, AuthError> {
+        let jwt = generate_gh_jwt(&self.credentials)?;
+        request_iat(&self.http_client, &jwt, subscriber).await
+    }
+}
 
 /// Credentials required for authentication.
 #[derive(Debug, Clone)]
@@ -88,7 +115,6 @@ pub(super) fn generate_gh_jwt(creds: &AuthCredentials) -> Result<String, AuthErr
 /// [iat_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
 pub(super) async fn request_iat(
     http_client: &Client,
-    api_base_url: &str,
     jwt: &str,
     sub: &Subscriber,
 ) -> Result<String, AuthError> {
@@ -98,8 +124,8 @@ pub(super) async fn request_iat(
     }
 
     let api_url = format!(
-        "{}/app/installations/{}/access_tokens",
-        api_base_url, sub.gh_app_installation_id
+        "https://api.github.com/app/installations/{}/access_tokens",
+        sub.gh_app_installation_id
     );
     let response = http_client
         .post(&api_url)

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -194,7 +194,7 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
-        sqlx::query!("INSERT INTO subscribers (branch_id, target_repo, event_type, gh_app_installation_id) VALUES (?, ?, ?, ?)", 
+        sqlx::query!("INSERT INTO subscribers (branch_id, target_repo, event_type, gh_app_installation_id) VALUES (?, ?, ?, ?)",
                      1, "org/target", "dispatch", 1)
             .execute(&pool)
             .await

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -20,53 +20,49 @@ pub use auth::*;
 mod auth;
 mod error;
 
-/// Spawns an asynchronous task to trigger repository workflows.
-///
-/// The spawned task will listen to [`BranchUpdateEvent`]s,
-/// triggering a workflow for each event it receives.
-pub fn start_trigger_engine(
-    ctx: SharedContext,
-    http_client: Client,
-    rx: Receiver<BranchUpdateEvent>,
-    creds: AuthCredentials,
-) {
-    tokio::spawn(async move {
-        info!("Trigger engine started");
-        trigger_loop(ctx, http_client, rx, creds).await;
-    });
+/// Runs an asynchronous task
+/// that triggers a workflow in a remote repository.
+pub struct TriggerEngine {
+    /// Shared data for all async engines.
+    pub ctx: SharedContext,
+
+    /// HTTP client to make requests to the GitHub API.
+    pub http_client: Client,
+
+    /// Receives [`BranchUpdateEvent`]s.
+    pub rx: Receiver<BranchUpdateEvent>,
+
+    /// Contains authentication credentials.
+    pub creds: AuthCredentials,
+}
+
+impl TriggerEngine {
+    /// Spawns an asynchronous task to trigger repository workflows.
+    ///
+    /// The spawned task will listen to [`BranchUpdateEvent`]s,
+    /// triggering a workflow for each event it receives.
+    pub fn start(self) {
+        tokio::spawn(async move {
+            info!("Trigger engine started");
+            trigger_loop(self).await;
+        });
+    }
 }
 
 /// Controls whether to shut down the trigger engine or process a [`BranchUpdateEvent`].
-async fn trigger_loop(
-    ctx: SharedContext,
-    http_client: Client,
-    mut rx: Receiver<BranchUpdateEvent>,
-    creds: AuthCredentials,
-) {
+async fn trigger_loop(mut engine: TriggerEngine) {
     loop {
         tokio::select! {
-            Some(event) = rx.recv() => handle_branch_update(&ctx, &http_client, event, &creds).await,
-            _ = ctx.token.cancelled() => break,
+            Some(event) = engine.rx.recv() => handle_branch_update(&engine, event).await,
+            _ = engine.ctx.token.cancelled() => break,
         }
     }
     info!("Gracefully shutting down trigger engine");
 }
 
 /// Handles a [`BranchUpdateEvent`], handling any possible error.
-async fn handle_branch_update(
-    ctx: &SharedContext,
-    http_client: &Client,
-    event: BranchUpdateEvent,
-    creds: &AuthCredentials,
-) {
-    let result = dispatch_events(
-        &ctx.db_pool,
-        &ctx.github_api_base_url,
-        http_client,
-        event,
-        creds,
-    )
-    .await;
+async fn handle_branch_update(engine: &TriggerEngine, event: BranchUpdateEvent) {
+    let result = dispatch_events(engine, event).await;
 
     if let Err(e) = result {
         error!("{e}");
@@ -75,23 +71,27 @@ async fn handle_branch_update(
 
 /// Sends a `repository_dispatch` event for each relevant [`Subscriber`].
 async fn dispatch_events(
-    pool: &SqlitePool,
-    api_base_url: &str,
-    http_client: &Client,
+    engine: &TriggerEngine,
     event: BranchUpdateEvent,
-    creds: &AuthCredentials,
 ) -> Result<(), WorkflowTriggerError> {
     info!(
         "Received update event for branch {}: {}",
         event.branch_id, event.new_hash
     );
 
-    let subscribers = get_subscribers(pool, &event).await?;
+    let subscribers = get_subscribers(&engine.ctx.db_pool, &event).await?;
 
-    let jwt = generate_gh_jwt(creds)?;
+    let jwt = generate_gh_jwt(&engine.creds)?;
 
     for sub in subscribers {
-        let result = notify_subscriber(http_client, api_base_url, &jwt, &event, sub).await;
+        let iat = request_iat(
+            &engine.http_client,
+            &engine.ctx.github_api_base_url,
+            &jwt,
+            &sub,
+        )
+        .await?;
+        let result = notify_subscriber(engine, iat, &event, sub).await;
         if let Err(e) = result {
             error!("{e:?}");
         }
@@ -117,26 +117,26 @@ async fn get_subscribers(
 /// Manages IAT authentication,
 /// and sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn notify_subscriber(
-    http_client: &Client,
-    api_base_url: &str,
-    jwt: &str,
+    engine: &TriggerEngine,
+    iat: String,
     event: &BranchUpdateEvent,
     sub: Subscriber,
 ) -> Result<(), WorkflowTriggerError> {
-    let iat = request_iat(http_client, api_base_url, jwt, &sub).await?;
-    send_repository_dispatch(http_client, api_base_url, &iat, event, &sub).await?;
+    send_repository_dispatch(engine, &iat, event, &sub).await?;
     Ok(())
 }
 
 /// Sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn send_repository_dispatch(
-    http_client: &Client,
-    api_base_url: &str,
+    engine: &TriggerEngine,
     iat: &str,
     event: &BranchUpdateEvent,
     sub: &Subscriber,
 ) -> Result<(), WorkflowTriggerError> {
-    let api_url = format!("{}/repos/{}/dispatches", api_base_url, sub.target_repo);
+    let api_url = format!(
+        "{}/repos/{}/dispatches",
+        engine.ctx.github_api_base_url, sub.target_repo
+    );
 
     let payload = serde_json::json!({
         "event_type": sub.event_type,
@@ -148,7 +148,8 @@ async fn send_repository_dispatch(
 
     info!("Sending payload to {}: {}", sub.target_repo, payload);
 
-    let response = http_client
+    let response = engine
+        .http_client
         .post(&api_url)
         .bearer_auth(iat)
         .header("Accept", "application/vnd.github+json")
@@ -173,9 +174,13 @@ async fn send_repository_dispatch(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::events::BranchUpdateEvent;
+    use crate::test_utils::MockGitFetcher;
     use crate::trigger::auth::AuthCredentials;
+    use tokio_util::sync::CancellationToken;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -227,7 +232,21 @@ mod tests {
             pem_path: "nilirad-relay-dev.pem".to_string(),
         };
 
-        let res = dispatch_events(&pool, &mock_server.uri(), &http_client, event, &creds).await;
+        let trigger_engine = TriggerEngine {
+            ctx: SharedContext {
+                db_pool: pool,
+                token: CancellationToken::new(),
+                github_api_base_url: mock_server.uri(),
+                git_fetcher: Arc::new(MockGitFetcher {
+                    hash: "".to_string(),
+                }),
+            },
+            http_client,
+            rx: tokio::sync::mpsc::channel::<BranchUpdateEvent>(1).1,
+            creds,
+        };
+
+        let res = dispatch_events(&trigger_engine, event).await;
         assert!(res.is_ok());
     }
 }

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -9,16 +9,13 @@ use crate::{
     context::SharedContext,
     events::BranchUpdateEvent,
     model::Subscriber,
-    trigger::{
-        auth::{generate_gh_jwt, request_iat},
-        error::{RequestError, WorkflowTriggerError},
-    },
+    trigger::error::{RequestError, WorkflowTriggerError},
 };
 
 pub use auth::*;
 
 mod auth;
-mod error;
+pub mod error;
 
 /// Runs an asynchronous task
 /// that triggers a workflow in a remote repository.
@@ -32,8 +29,8 @@ pub struct TriggerEngine {
     /// Receives [`BranchUpdateEvent`]s.
     pub rx: Receiver<BranchUpdateEvent>,
 
-    /// Contains authentication credentials.
-    pub creds: AuthCredentials,
+    /// Authenticates requests to the GitHub API.
+    pub authenticator: Box<dyn Authenticator + Send + Sync>,
 }
 
 impl TriggerEngine {
@@ -81,16 +78,11 @@ async fn dispatch_events(
 
     let subscribers = get_subscribers(&engine.ctx.db_pool, &event).await?;
 
-    let jwt = generate_gh_jwt(&engine.creds)?;
-
     for sub in subscribers {
-        let iat = request_iat(
-            &engine.http_client,
-            &engine.ctx.github_api_base_url,
-            &jwt,
-            &sub,
-        )
-        .await?;
+        let iat = engine
+            .authenticator
+            .request_installation_token(&sub)
+            .await?;
         let result = notify_subscriber(engine, iat, &event, sub).await;
         if let Err(e) = result {
             error!("{e:?}");
@@ -178,8 +170,8 @@ mod tests {
 
     use super::*;
     use crate::events::BranchUpdateEvent;
-    use crate::test_utils::MockGitFetcher;
-    use crate::trigger::auth::AuthCredentials;
+    use crate::test_utils::{MockAuthenticator, MockGitFetcher};
+
     use tokio_util::sync::CancellationToken;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -227,11 +219,6 @@ mod tests {
             new_hash: "new-hash".to_string(),
         };
 
-        let creds = AuthCredentials {
-            client_id: "mock-client-id".to_string(),
-            pem_path: "nilirad-relay-dev.pem".to_string(),
-        };
-
         let trigger_engine = TriggerEngine {
             ctx: SharedContext {
                 db_pool: pool,
@@ -243,7 +230,9 @@ mod tests {
             },
             http_client,
             rx: tokio::sync::mpsc::channel::<BranchUpdateEvent>(1).1,
-            creds,
+            authenticator: Box::new(MockAuthenticator {
+                iat: "Test IAT".to_string(),
+            }),
         };
 
         let res = dispatch_events(&trigger_engine, event).await;

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -45,7 +45,7 @@ async fn trigger_loop(
 ) {
     loop {
         tokio::select! {
-            Some(event) = rx.recv() => handle_branch_update(&ctx.db_pool, &http_client, event, &creds).await,
+            Some(event) = rx.recv() => handle_branch_update(&ctx, &http_client, event, &creds).await,
             _ = ctx.token.cancelled() => break,
         }
     }
@@ -54,12 +54,19 @@ async fn trigger_loop(
 
 /// Handles a [`BranchUpdateEvent`], handling any possible error.
 async fn handle_branch_update(
-    pool: &SqlitePool,
+    ctx: &SharedContext,
     http_client: &Client,
     event: BranchUpdateEvent,
     creds: &AuthCredentials,
 ) {
-    let result = dispatch_events(pool, http_client, event, creds).await;
+    let result = dispatch_events(
+        &ctx.db_pool,
+        &ctx.github_api_base_url,
+        http_client,
+        event,
+        creds,
+    )
+    .await;
 
     if let Err(e) = result {
         error!("{e}");
@@ -69,6 +76,7 @@ async fn handle_branch_update(
 /// Sends a `repository_dispatch` event for each relevant [`Subscriber`].
 async fn dispatch_events(
     pool: &SqlitePool,
+    api_base_url: &str,
     http_client: &Client,
     event: BranchUpdateEvent,
     creds: &AuthCredentials,
@@ -83,7 +91,7 @@ async fn dispatch_events(
     let jwt = generate_gh_jwt(creds)?;
 
     for sub in subscribers {
-        let result = notify_subscriber(http_client, &jwt, &event, sub).await;
+        let result = notify_subscriber(http_client, api_base_url, &jwt, &event, sub).await;
         if let Err(e) = result {
             error!("{e:?}");
         }
@@ -110,26 +118,25 @@ async fn get_subscribers(
 /// and sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn notify_subscriber(
     http_client: &Client,
+    api_base_url: &str,
     jwt: &str,
     event: &BranchUpdateEvent,
     sub: Subscriber,
 ) -> Result<(), WorkflowTriggerError> {
-    let iat = request_iat(http_client, jwt, &sub).await?;
-    send_repository_dispatch(http_client, &iat, event, &sub).await?;
+    let iat = request_iat(http_client, api_base_url, jwt, &sub).await?;
+    send_repository_dispatch(http_client, api_base_url, &iat, event, &sub).await?;
     Ok(())
 }
 
 /// Sends a `repository_dispatch` event to the specified [`Subscriber`].
 async fn send_repository_dispatch(
     http_client: &Client,
+    api_base_url: &str,
     iat: &str,
     event: &BranchUpdateEvent,
     sub: &Subscriber,
 ) -> Result<(), WorkflowTriggerError> {
-    let api_url = format!(
-        "https://api.github.com/repos/{}/dispatches",
-        sub.target_repo
-    );
+    let api_url = format!("{}/repos/{}/dispatches", api_base_url, sub.target_repo);
 
     let payload = serde_json::json!({
         "event_type": sub.event_type,
@@ -161,5 +168,66 @@ async fn send_repository_dispatch(
             status: response.status(),
             text: response.text().await?,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::BranchUpdateEvent;
+    use crate::trigger::auth::AuthCredentials;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_dispatch_events() {
+        let pool = crate::test_utils::create_test_db().await;
+        let mock_server = MockServer::start().await;
+        let http_client = reqwest::Client::new();
+
+        // Setup mock subscriber in DB
+        sqlx::query!(
+            "INSERT INTO branches (repo_url, name) VALUES (?, ?)",
+            "repo",
+            "main"
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query!("INSERT INTO subscribers (branch_id, target_repo, event_type, gh_app_installation_id) VALUES (?, ?, ?, ?)", 
+                     1, "org/target", "dispatch", 1)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Mock IAT token request
+        Mock::given(method("POST"))
+            .and(path("/app/installations/1/access_tokens"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "mock-iat-token"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Mock repository dispatch
+        Mock::given(method("POST"))
+            .and(path("/repos/org/target/dispatches"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let event = BranchUpdateEvent {
+            branch_id: 1,
+            new_hash: "new-hash".to_string(),
+        };
+
+        let creds = AuthCredentials {
+            client_id: "mock-client-id".to_string(),
+            pem_path: "nilirad-relay-dev.pem".to_string(),
+        };
+
+        let res = dispatch_events(&pool, &mock_server.uri(), &http_client, event, &creds).await;
+        assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
- Closes #13 

This draft PR adds basic test coverage to the core features of the server (polling and trigger engines, and subscriber creation route). The bulk of the work is done, the only thing that remains is to clean up the code before merging it, since the addition of the `GitFetcher` trait, used for dependency injection, bloated some function signatures.