### PR TITLE
Unify async engines under the `AsyncEngine` trait

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,6 @@
 //! Interface definitions for async engines.
 
 use async_trait::async_trait;
-use std::sync::Arc;
 
 use tracing::info;
 
@@ -13,7 +12,7 @@ pub trait AsyncEngine: Send + Sync + 'static {
 }
 
 /// Starts the engine by spawning it in a new task.
-pub fn start_engine<E: AsyncEngine + ?Sized>(engine: Arc<E>, message: &str) {
+pub fn start_engine(engine: Box<dyn AsyncEngine>, message: &str) {
     info!(message);
     tokio::spawn(async move {
         engine.run().await;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,20 @@
+//! Interface definitions for async engines.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use tracing::info;
+
+/// Defines the interface of an asynchronous backround running engine.
+#[async_trait]
+pub trait AsyncEngine: Send + Sync + 'static {
+    /// Starts the engine.
+    fn start(self: Arc<Self>, message: &str) {
+        info!(message);
+        tokio::spawn(async move {
+            self.loop_function().await;
+        });
+    }
+
+    async fn loop_function(&self);
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,16 +5,17 @@ use std::sync::Arc;
 
 use tracing::info;
 
-/// Defines the interface of an asynchronous backround running engine.
+/// Defines the interface of an asynchronous background running engine.
 #[async_trait]
 pub trait AsyncEngine: Send + Sync + 'static {
-    /// Starts the engine.
-    fn start(self: Arc<Self>, message: &str) {
-        info!(message);
-        tokio::spawn(async move {
-            self.loop_function().await;
-        });
-    }
+    /// The core execution loop of the engine.
+    async fn run(&self);
+}
 
-    async fn loop_function(&self);
+/// Starts the engine by spawning it in a new task.
+pub fn start_engine<E: AsyncEngine + ?Sized>(engine: Arc<E>, message: &str) {
+    info!(message);
+    tokio::spawn(async move {
+        engine.run().await;
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,30 +42,52 @@ async fn main() {
     run_app().await.unwrap_or_else(|e| error!("{e}"));
 }
 
+/// A task for an engine to be started.
+type EngineTask = (Box<dyn AsyncEngine>, &'static str);
+
 /// Runs the server, delegating errors to the caller.
 async fn run_app() -> Result<(), FatalError> {
     tracing_subscriber::fmt::init();
 
+    let pool = init_database().await?;
+    let http_client = build_http_client()?;
+
+    let ctx = init_context(pool.clone());
+
+    crate::trigger::recover_stuck_tasks(&pool).await?;
+
+    let engines = init_engines(&ctx, http_client)?;
+    for (engine, message) in engines {
+        crate::engine::start_engine(engine, message);
+    }
+
+    let app = build_router(pool);
+
+    run_server(app, ctx.token.clone()).await
+}
+
+/// Initializes the database pool.
+async fn init_database() -> Result<sqlx::SqlitePool, FatalError> {
     let pool = sqlx::sqlite::SqlitePoolOptions::new()
         .acquire_timeout(std::time::Duration::from_secs(3))
         .connect("sqlite://relay.db?mode=rwc")
         .await?;
-    let state = AppState {
-        db_pool: pool.clone(),
-    };
+    Ok(pool)
+}
 
-    let http_client = build_http_client()?;
-
+/// Initializes the shared application context.
+fn init_context(pool: sqlx::SqlitePool) -> SharedContext {
     let token = CancellationToken::new();
-    let ctx = SharedContext {
-        db_pool: pool.clone(),
-        token: token.clone(),
+    SharedContext {
+        db_pool: pool,
+        token,
         github_api_base_url: "https://api.github.com".to_string(),
         git_fetcher: std::sync::Arc::new(crate::polling::git::MainGitFetcher),
-    };
+    }
+}
 
-    crate::trigger::recover_stuck_tasks(&pool).await?;
-
+/// Initializes the background engines.
+fn init_engines(ctx: &SharedContext, http_client: Client) -> Result<Vec<EngineTask>, FatalError> {
     let polling_engine = PollingEngine { ctx: ctx.clone() };
 
     let authenticator = Box::new(GitHubAuthenticator {
@@ -73,25 +95,29 @@ async fn run_app() -> Result<(), FatalError> {
         http_client: http_client.clone(),
     });
     let trigger_engine = TriggerEngine {
-        ctx,
+        ctx: ctx.clone(),
         http_client,
         authenticator,
     };
 
-    let engines: Vec<(Box<dyn AsyncEngine>, &str)> = vec![
+    Ok(vec![
         (Box::new(polling_engine), "Starting polling engine"),
         (Box::new(trigger_engine), "Starting trigger engine"),
-    ];
+    ])
+}
 
-    for (engine, message) in engines {
-        crate::engine::start_engine(engine, message);
-    }
-
-    let app = Router::new()
+/// Builds the application router.
+fn build_router(pool: sqlx::SqlitePool) -> Router {
+    let state = AppState { db_pool: pool };
+    Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))
         .route("/branches", post(create_branch))
         .route("/subscribers", post(create_subscriber))
-        .with_state(state);
+        .with_state(state)
+}
+
+/// Runs the server.
+async fn run_server(app: Router, token: CancellationToken) -> Result<(), FatalError> {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
         .await
         .map_err(FatalError::TcpBinding)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,13 @@ use axum::{
     routing::{get, post},
 };
 use reqwest::Client;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::{
     context::SharedContext,
+    engine::AsyncEngine,
     error::{ClientCreationError, FatalError},
     handler::{create_branch, create_subscriber},
     polling::PollingEngine,
@@ -26,6 +28,7 @@ use crate::{
 };
 
 mod context;
+mod engine;
 mod error;
 mod handler;
 mod model;
@@ -64,20 +67,20 @@ async fn run_app() -> Result<(), FatalError> {
 
     crate::trigger::recover_stuck_tasks(&pool).await?;
 
-    let polling_engine = PollingEngine { ctx: ctx.clone() };
+    let polling_engine = Arc::new(PollingEngine { ctx: ctx.clone() });
 
     let authenticator = Box::new(GitHubAuthenticator {
         credentials: get_auth_credentials()?,
         http_client: http_client.clone(),
     });
-    let trigger_engine = TriggerEngine {
+    let trigger_engine = Arc::new(TriggerEngine {
         ctx,
         http_client,
         authenticator,
-    };
+    });
 
-    polling_engine.start();
-    trigger_engine.start();
+    polling_engine.clone().start("Polling engine started");
+    trigger_engine.clone().start("Trigger engine started");
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,14 @@ async fn run_app() -> Result<(), FatalError> {
         authenticator,
     });
 
-    polling_engine.clone().start("Polling engine started");
-    trigger_engine.clone().start("Trigger engine started");
+    let async_engines: Vec<(Arc<dyn AsyncEngine>, &str)> = vec![
+        (polling_engine, "Starting polling engine"),
+        (trigger_engine, "Starting trigger engine"),
+    ];
+
+    for (engine, message) in async_engines {
+        crate::engine::start_engine(engine, message);
+    }
 
     let app = Router::new()
         .route("/health", get(|| async { "Relay Server is alive" }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crate::{
     context::SharedContext,
     error::{ClientCreationError, FatalError},
     handler::{create_branch, create_subscriber},
+    polling::PollingEngine,
     state::AppState,
     trigger::{GitHubAuthenticator, TriggerEngine, get_auth_credentials},
 };
@@ -63,7 +64,7 @@ async fn run_app() -> Result<(), FatalError> {
 
     crate::trigger::recover_stuck_tasks(&pool).await?;
 
-    polling::start_polling_engine(ctx.clone());
+    let polling_engine = PollingEngine { ctx: ctx.clone() };
 
     let authenticator = Box::new(GitHubAuthenticator {
         credentials: get_auth_credentials()?,
@@ -75,6 +76,7 @@ async fn run_app() -> Result<(), FatalError> {
         authenticator,
     };
 
+    polling_engine.start();
     trigger_engine.start();
 
     let app = Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use axum::{
     routing::{get, post},
 };
 use reqwest::Client;
-use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
@@ -67,24 +66,24 @@ async fn run_app() -> Result<(), FatalError> {
 
     crate::trigger::recover_stuck_tasks(&pool).await?;
 
-    let polling_engine = Arc::new(PollingEngine { ctx: ctx.clone() });
+    let polling_engine = PollingEngine { ctx: ctx.clone() };
 
     let authenticator = Box::new(GitHubAuthenticator {
         credentials: get_auth_credentials()?,
         http_client: http_client.clone(),
     });
-    let trigger_engine = Arc::new(TriggerEngine {
+    let trigger_engine = TriggerEngine {
         ctx,
         http_client,
         authenticator,
-    });
+    };
 
-    let async_engines: Vec<(Arc<dyn AsyncEngine>, &str)> = vec![
-        (polling_engine, "Starting polling engine"),
-        (trigger_engine, "Starting trigger engine"),
+    let engines: Vec<(Box<dyn AsyncEngine>, &str)> = vec![
+        (Box::new(polling_engine), "Starting polling engine"),
+        (Box::new(trigger_engine), "Starting trigger engine"),
     ];
 
-    for (engine, message) in async_engines {
+    for (engine, message) in engines {
         crate::engine::start_engine(engine, message);
     }
 

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -29,7 +29,7 @@ pub struct PollingEngine {
 
 #[async_trait]
 impl AsyncEngine for PollingEngine {
-    async fn loop_function(&self) {
+    async fn run(&self) {
         polling_loop(self.ctx.clone()).await;
     }
 }

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -18,11 +18,28 @@ mod db;
 mod error;
 pub mod git;
 
+/// Runs an asynchronous task
+/// that periodically polls git branches in remote repositories.
+pub struct PollingEngine {
+    /// Shared data for all async engines.
+    pub ctx: SharedContext,
+}
+
+impl PollingEngine {
+    /// Spawns an asynchronous task to poll remote git branches.
+    pub fn start(self) {
+        tokio::spawn(async move {
+            info!("Polling engine started");
+            start_polling_engine(self).await;
+        });
+    }
+}
+
 /// Spawns an asynchronous task to periodically poll git branches for updates.
-pub fn start_polling_engine(ctx: SharedContext) {
+async fn start_polling_engine(engine: PollingEngine) {
     tokio::spawn(async move {
         info!("Polling engine started");
-        polling_loop(ctx).await;
+        polling_loop(engine.ctx).await;
     });
 }
 

--- a/src/polling/mod.rs
+++ b/src/polling/mod.rs
@@ -1,5 +1,6 @@
 //! Asynchronous task to periodically check for updated remote branches.
 
+use async_trait::async_trait;
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
@@ -7,6 +8,7 @@ use tracing::info;
 
 use crate::{
     context::SharedContext,
+    engine::AsyncEngine,
     polling::{
         db::gather_updated_branches,
         error::{PollingError, handle_polling_error},
@@ -25,22 +27,11 @@ pub struct PollingEngine {
     pub ctx: SharedContext,
 }
 
-impl PollingEngine {
-    /// Spawns an asynchronous task to poll remote git branches.
-    pub fn start(self) {
-        tokio::spawn(async move {
-            info!("Polling engine started");
-            start_polling_engine(self).await;
-        });
+#[async_trait]
+impl AsyncEngine for PollingEngine {
+    async fn loop_function(&self) {
+        polling_loop(self.ctx.clone()).await;
     }
-}
-
-/// Spawns an asynchronous task to periodically poll git branches for updates.
-async fn start_polling_engine(engine: PollingEngine) {
-    tokio::spawn(async move {
-        info!("Polling engine started");
-        polling_loop(engine.ctx).await;
-    });
 }
 
 /// Controls whether to shut down the polling engine or run a polling cycle.

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -1,18 +1,19 @@
 //! Asynchronous task to trigger remote repository workflows.
 
+use async_trait::async_trait;
 use reqwest::Client;
 use sqlx::SqlitePool;
 use tracing::{info, warn};
 
 use crate::{
     context::SharedContext,
+    engine::AsyncEngine,
     model::{Subscriber, TriggerQueueItem},
     trigger::error::{RequestError, WorkflowTriggerError},
 };
 
-pub use auth::*;
-
 mod auth;
+pub use auth::{Authenticator, GitHubAuthenticator, get_auth_credentials};
 pub mod error;
 
 /// Runs an asynchronous task
@@ -28,27 +29,21 @@ pub struct TriggerEngine {
     pub authenticator: Box<dyn Authenticator + Send + Sync>,
 }
 
-impl TriggerEngine {
-    /// Spawns an asynchronous task to trigger repository workflows.
-    ///
-    /// The spawned task will periodically read the `trigger_queue` table,
-    /// triggering a workflow for each event it processes.
-    pub fn start(self) {
-        tokio::spawn(async move {
-            info!("Trigger engine started");
-            trigger_loop(self).await;
-        });
+#[async_trait]
+impl AsyncEngine for TriggerEngine {
+    async fn loop_function(&self) {
+        trigger_loop(self).await;
     }
 }
 
 /// Controls whether to shut down the trigger engine or process a queued event.
-async fn trigger_loop(engine: TriggerEngine) {
+async fn trigger_loop(engine: &TriggerEngine) {
     const QUEUE_POLLING_INTERVAL_SECS: u64 = 5;
     loop {
         tokio::select! {
             _ = engine.ctx.token.cancelled() => break,
             _ = tokio::time::sleep(tokio::time::Duration::from_secs(QUEUE_POLLING_INTERVAL_SECS)) => {
-                if let Err(e) = process_queue(&engine).await {
+                if let Err(e) = process_queue(engine).await {
                     warn!("Error processing queue: {e}");
                 }
             }

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -31,7 +31,7 @@ pub struct TriggerEngine {
 
 #[async_trait]
 impl AsyncEngine for TriggerEngine {
-    async fn loop_function(&self) {
+    async fn run(&self) {
         trigger_loop(self).await;
     }
 }


### PR DESCRIPTION
- Closes #42 

This PR adds an object-safe `AsyncEngine` trait, abstracting a common interface between `PollingEngine` and `TriggerEngine`. This is used to collect both engines and start them in a loop.