### PR TITLE
Align with REST architectural constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,6 +1819,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tower-http = { version = "0.6", features = ["timeout"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3"
 validator = { version = "0.20.0", features = ["derive"] }
+tower = { version = "0.5.3", features = ["util"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/http/requests.http
+++ b/http/requests.http
@@ -3,9 +3,9 @@
 @targetRepo = my-org/my-target-repo
 @eventType = event_type
 @installationId = 12345678
+@subscriberId = 1
 
 ### Create subscription
-
 POST http://localhost:3000/subscribers
 Content-Type: application/json
 
@@ -16,3 +16,20 @@ Content-Type: application/json
   "event_type": "{{eventType}}",
   "gh_app_installation_id": {{installationId}}
 }
+
+### List subscribers
+GET http://localhost:3000/subscribers
+
+### Get subscriber
+GET http://localhost:3000/subscribers/{{subscriberId}}
+
+### Update subscriber
+PATCH http://localhost:3000/subscribers/{{subscriberId}}
+Content-Type: application/json
+
+{
+  "target_repo": "my-org/new-target-repo"
+}
+
+### Delete subscriber
+DELETE http://localhost:3000/subscribers/{{subscriberId}}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,9 @@
 //! Axum route handlers.
 
 use crate::error::HandlerError;
-use crate::model::{CreateSubscriber, Subscriber, UpdateSubscriber};
+use crate::model::{
+    CreateSubscriber, HalLink, Subscriber, SubscriberHal, SubscriberLinks, UpdateSubscriber,
+};
 use crate::state::AppState;
 use axum::{
     Json,
@@ -9,11 +11,30 @@ use axum::{
 };
 use tracing::info;
 
+/// Maps a [`Subscriber`] to its HAL representation.
+fn map_to_hal(subscriber: Subscriber) -> SubscriberHal {
+    let id = subscriber.id;
+    SubscriberHal {
+        subscriber,
+        links: SubscriberLinks {
+            self_link: HalLink {
+                href: format!("/subscribers/{}", id),
+            },
+            update: HalLink {
+                href: format!("/subscribers/{}", id),
+            },
+            delete: HalLink {
+                href: format!("/subscribers/{}", id),
+            },
+        },
+    }
+}
+
 /// Stores a new [`Subscriber`] in the database.
 pub async fn create_subscriber(
     State(state): State<AppState>,
     Json(payload): Json<CreateSubscriber>,
-) -> Result<Json<Subscriber>, HandlerError> {
+) -> Result<Json<SubscriberHal>, HandlerError> {
     let mut transaction = state.db_pool.begin().await?;
     let branch_id = get_or_insert_branch_id(&mut transaction, &payload).await?;
     let subscriber = sqlx::query_as::<_, Subscriber>(
@@ -29,30 +50,30 @@ pub async fn create_subscriber(
 
     info!("Registered new subscriber for branch ID {branch_id}: {subscriber:?}");
 
-    Ok(Json(subscriber))
+    Ok(Json(map_to_hal(subscriber)))
 }
 
 /// Retrieves all [`Subscriber`]s.
 pub async fn list_subscribers(
     State(state): State<AppState>,
-) -> Result<Json<Vec<Subscriber>>, HandlerError> {
+) -> Result<Json<Vec<SubscriberHal>>, HandlerError> {
     let subscribers = sqlx::query_as::<_, Subscriber>("SELECT * FROM subscribers")
         .fetch_all(&state.db_pool)
         .await?;
-    Ok(Json(subscribers))
+    Ok(Json(subscribers.into_iter().map(map_to_hal).collect()))
 }
 
 /// Retrieves a specific [`Subscriber`] by ID.
 pub async fn get_subscriber(
     State(state): State<AppState>,
     Path(id): Path<i64>,
-) -> Result<Json<Subscriber>, HandlerError> {
+) -> Result<Json<SubscriberHal>, HandlerError> {
     let subscriber = sqlx::query_as::<_, Subscriber>("SELECT * FROM subscribers WHERE id = ?")
         .bind(id)
         .fetch_optional(&state.db_pool)
         .await?
         .ok_or(HandlerError::NotFound)?;
-    Ok(Json(subscriber))
+    Ok(Json(map_to_hal(subscriber)))
 }
 
 /// Updates an existing [`Subscriber`].
@@ -60,7 +81,7 @@ pub async fn update_subscriber(
     State(state): State<AppState>,
     Path(id): Path<i64>,
     Json(payload): Json<UpdateSubscriber>,
-) -> Result<Json<Subscriber>, HandlerError> {
+) -> Result<Json<SubscriberHal>, HandlerError> {
     let mut query_builder = sqlx::QueryBuilder::new("UPDATE subscribers SET ");
     let mut separated = query_builder.separated(", ");
 
@@ -92,7 +113,7 @@ pub async fn update_subscriber(
         .await?
         .ok_or(HandlerError::NotFound)?;
 
-    Ok(Json(subscriber))
+    Ok(Json(map_to_hal(subscriber)))
 }
 
 /// Deletes a [`Subscriber`] by ID.
@@ -172,17 +193,20 @@ mod tests {
         let res = create_subscriber(State(state.clone()), Json(payload))
             .await
             .unwrap();
-        let id = res.id;
+        let id = res.subscriber.id;
+        assert_eq!(res.links.self_link.href, format!("/subscribers/{}", id));
 
         // List
         let list = list_subscribers(State(state.clone())).await.unwrap();
         assert_eq!(list.len(), 1);
+        assert_eq!(list[0].links.self_link.href, format!("/subscribers/{}", id));
 
         // Get
         let get = get_subscriber(State(state.clone()), Path(id))
             .await
             .unwrap();
-        assert_eq!(get.id, id);
+        assert_eq!(get.subscriber.id, id);
+        assert_eq!(get.links.self_link.href, format!("/subscribers/{}", id));
 
         // Update
         let update_payload = UpdateSubscriber {
@@ -193,7 +217,11 @@ mod tests {
         let updated = update_subscriber(State(state.clone()), Path(id), Json(update_payload))
             .await
             .unwrap();
-        assert_eq!(updated.target_repo, "https://github.com/org/new-target");
+        assert_eq!(
+            updated.subscriber.target_repo,
+            "https://github.com/org/new-target"
+        );
+        assert_eq!(updated.links.self_link.href, format!("/subscribers/{}", id));
 
         // Delete
         delete_subscriber(State(state.clone()), Path(id))

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
             post(create_subscriber).get(list_subscribers),
         )
         .route(
-            "/subscribers/:id",
+            "/subscribers/{id}",
             get(get_subscriber)
                 .put(update_subscriber)
                 .delete(delete_subscriber),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use axum::{
     Router,
     http::{HeaderValue, Request, Response, header},
     middleware::{self, Next},
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post},
 };
 use reqwest::{Client, StatusCode};
 use tokio_util::sync::CancellationToken;
@@ -141,7 +141,7 @@ fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
         .route(
             "/subscribers/{id}",
             get(get_subscriber)
-                .put(update_subscriber)
+                .patch(update_subscriber)
                 .delete(delete_subscriber),
         )
         .layer(middleware::from_fn(set_no_cache_header));

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,12 @@
     clippy::indexing_slicing
 )]
 
+use axum::body::Body;
 #[allow(unused_imports)]
 use axum::{
     Router,
+    http::{HeaderValue, Request, Response, header},
+    middleware::{self, Next},
     routing::{delete, get, post, put},
 };
 use reqwest::{Client, StatusCode};
@@ -115,11 +118,22 @@ fn init_engines(ctx: &SharedContext, http_client: Client) -> Result<Vec<EngineTa
     ])
 }
 
+/// Middleware to set Cache-Control header.
+async fn set_no_cache_header(req: Request<Body>, next: Next) -> Response<Body> {
+    let mut response = next.run(req).await;
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-cache, no-store, must-revalidate, max-age=0"),
+    );
+    response
+}
+
 /// Builds the application router.
 fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
     let state = AppState { db_pool: pool };
-    Router::new()
-        .route("/health", get(|| async { "Relay Server is alive" }))
+
+    let subscribers = Router::new()
+        .route("/", post(create_subscriber).get(list_subscribers))
         .route(
             "/subscribers",
             post(create_subscriber).get(list_subscribers),
@@ -130,6 +144,11 @@ fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
                 .put(update_subscriber)
                 .delete(delete_subscriber),
         )
+        .layer(middleware::from_fn(set_no_cache_header));
+
+    Router::new()
+        .route("/health", get(|| async { "Relay Server is alive" }))
+        .nest("/subscribers", subscribers)
         .with_state(state)
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ mod polling;
 mod state;
 #[cfg(test)]
 mod test_utils;
+#[cfg(test)]
+mod tests;
 mod trigger;
 
 #[tokio::main]
@@ -129,17 +131,13 @@ async fn set_no_cache_header(req: Request<Body>, next: Next) -> Response<Body> {
 }
 
 /// Builds the application router.
-fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
+pub fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
     let state = AppState { db_pool: pool };
 
     let subscribers = Router::new()
         .route("/", post(create_subscriber).get(list_subscribers))
         .route(
-            "/subscribers",
-            post(create_subscriber).get(list_subscribers),
-        )
-        .route(
-            "/subscribers/{id}",
+            "/{id}",
             get(get_subscriber)
                 .patch(update_subscriber)
                 .delete(delete_subscriber),

--- a/src/model.rs
+++ b/src/model.rs
@@ -63,6 +63,36 @@ pub struct Subscriber {
     pub updated_at: String,
 }
 
+/// HAL link structure.
+#[derive(Serialize)]
+pub struct HalLink {
+    /// URL of the link.
+    pub href: String,
+}
+
+/// HAL links for a subscriber.
+#[derive(Serialize)]
+pub struct SubscriberLinks {
+    /// Self link.
+    #[serde(rename = "self")]
+    pub self_link: HalLink,
+    /// Update link.
+    pub update: HalLink,
+    /// Delete link.
+    pub delete: HalLink,
+}
+
+/// HAL representation of a subscriber.
+#[derive(Serialize)]
+pub struct SubscriberHal {
+    /// The subscriber data.
+    #[serde(flatten)]
+    pub subscriber: Subscriber,
+    /// HAL links.
+    #[serde(rename = "_links")]
+    pub links: SubscriberLinks,
+}
+
 /// Holds payload data for the creation of a [`Subscriber`].
 #[derive(Debug, Deserialize)]
 pub struct CreateSubscriber {

--- a/src/tests/api_routes.rs
+++ b/src/tests/api_routes.rs
@@ -1,0 +1,106 @@
+use crate::{build_router, config::Config, test_utils::create_test_db};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt; // for oneshot
+
+#[tokio::test]
+async fn test_subscriber_api_routes() {
+    let pool = create_test_db().await;
+    let config = Config::default();
+
+    let app = build_router(pool, &config);
+
+    // Test List Subscribers (Empty)
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/subscribers")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test Create Subscriber
+    let payload = serde_json::json!({
+        "source_repo_url": "https://github.com/org/repo",
+        "source_branch_name": "main",
+        "target_repo": "org/target",
+        "event_type": "dispatch",
+        "gh_app_installation_id": 1
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/subscribers")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Get the ID from the response (it will be 1)
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let id = body_json["id"].as_i64().unwrap();
+    assert_eq!(id, 1);
+
+    // Test Get Subscriber
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/subscribers/{}", id))
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test Delete Subscriber
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/subscribers/{}", id))
+                .method("DELETE")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify deletion
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/subscribers/{}", id))
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,9 @@
+#![allow(
+    clippy::panic,
+    clippy::expect_used,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+
+pub mod api_routes;


### PR DESCRIPTION
- Closes #49 
- Closes #57 

This PR makes the API more RESTful by adding HAL links into responses and a `cache-control` HTTP header. Various fixes have also been made: `requests.http` have been updated, and updating a subscriber uses `PATCH` instead of `PUT`.