### PR TITLE
Add Scalar UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6966317188cdfe54c58c0900a195d021294afb3ece9b7073d09e4018dbb1e3a2"
+dependencies = [
+ "axum",
+ "bytes",
+ "cfg-if",
+ "http",
+ "indexmap",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 2.0.18",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +505,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1123,6 +1150,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1775,6 +1804,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +1861,7 @@ dependencies = [
  "futures",
  "jsonwebtoken",
  "reqwest",
+ "rovo",
  "serde",
  "serde_json",
  "sqlx",
@@ -1889,6 +1939,31 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rovo"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3330342aa9d16f56b04bb8e9981754f8761effbb2194b6af23ccf56ac06fb830"
+dependencies = [
+ "aide",
+ "axum",
+ "rovo-macros",
+ "schemars",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "rovo-macros"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ac0fd158aeb9b9d1c3208487e3f19c09273d76cad3ea9ad52a71d454f6d60b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2033,6 +2108,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2249,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2271,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2853,6 +2992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +3020,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 
 [[package]]
 name = "validator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3"
 validator = { version = "0.20.0", features = ["derive"] }
 tower = { version = "0.5.3", features = ["util"] }
+rovo = { version = "0.4.8", features = ["scalar"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ curl -X POST http://localhost:3000/subscribers \
 Make sure that `EVENT_TYPE` is the same
 as the one defined in the workflow.
 
+<!-- Scalar UI -->
+You can also access the API documentation and testing interface
+via the Scalar UI by navigating to `/scalar` on your server
+(e.g., http://localhost:3000/scalar).
+
 <!-- Wait for changes -->
 At this point,
 the server is ready to listen to the source repository

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use rovo::aide::OperationOutput;
 use thiserror::Error;
 
 /// An error happened inside an Axum handler.
@@ -16,6 +17,10 @@ pub enum HandlerError {
     /// Requested resource not found.
     #[error("Not Found")]
     NotFound,
+}
+
+impl OperationOutput for HandlerError {
+    type Inner = ();
 }
 
 impl IntoResponse for HandlerError {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -220,7 +220,10 @@ async fn update_subscriber_inner(
 ///
 /// @tag subscribers
 #[rovo]
-pub async fn delete_subscriber(state: State<AppState>, Path(id): Path<i64>) -> Result<(), HandlerError> {
+pub async fn delete_subscriber(
+    state: State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<(), HandlerError> {
     delete_subscriber_inner(state, Path(id)).await
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,6 +9,7 @@ use axum::{
     Json,
     extract::{Path, State},
 };
+use rovo::rovo;
 use tracing::info;
 
 /// Maps a [`Subscriber`] to its HAL representation.
@@ -31,7 +32,16 @@ fn map_to_hal(subscriber: Subscriber) -> SubscriberHal {
 }
 
 /// Stores a new [`Subscriber`] in the database.
+#[rovo]
 pub async fn create_subscriber(
+    state: State<AppState>,
+    payload: Json<CreateSubscriber>,
+) -> Result<Json<SubscriberHal>, HandlerError> {
+    create_subscriber_inner(state, payload).await
+}
+
+/// Internal implementation of [`create_subscriber`].
+async fn create_subscriber_inner(
     State(state): State<AppState>,
     Json(payload): Json<CreateSubscriber>,
 ) -> Result<Json<SubscriberHal>, HandlerError> {
@@ -54,7 +64,15 @@ pub async fn create_subscriber(
 }
 
 /// Retrieves all [`Subscriber`]s.
+#[rovo]
 pub async fn list_subscribers(
+    state: State<AppState>,
+) -> Result<Json<Vec<SubscriberHal>>, HandlerError> {
+    list_subscribers_inner(state).await
+}
+
+/// Internal implementation of [`list_subscribers`].
+async fn list_subscribers_inner(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SubscriberHal>>, HandlerError> {
     let subscribers = sqlx::query_as::<_, Subscriber>("SELECT * FROM subscribers")
@@ -64,7 +82,16 @@ pub async fn list_subscribers(
 }
 
 /// Retrieves a specific [`Subscriber`] by ID.
+#[rovo]
 pub async fn get_subscriber(
+    state: State<AppState>,
+    id: Path<i64>,
+) -> Result<Json<SubscriberHal>, HandlerError> {
+    get_subscriber_inner(state, id).await
+}
+
+/// Internal implementation of [`get_subscriber`].
+async fn get_subscriber_inner(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<Json<SubscriberHal>, HandlerError> {
@@ -77,7 +104,17 @@ pub async fn get_subscriber(
 }
 
 /// Updates an existing [`Subscriber`].
+#[rovo]
 pub async fn update_subscriber(
+    state: State<AppState>,
+    id: Path<i64>,
+    payload: Json<UpdateSubscriber>,
+) -> Result<Json<SubscriberHal>, HandlerError> {
+    update_subscriber_inner(state, id, payload).await
+}
+
+/// Internal implementation of [`update_subscriber`].
+async fn update_subscriber_inner(
     State(state): State<AppState>,
     Path(id): Path<i64>,
     Json(payload): Json<UpdateSubscriber>,
@@ -117,7 +154,13 @@ pub async fn update_subscriber(
 }
 
 /// Deletes a [`Subscriber`] by ID.
-pub async fn delete_subscriber(
+#[rovo]
+pub async fn delete_subscriber(state: State<AppState>, id: Path<i64>) -> Result<(), HandlerError> {
+    delete_subscriber_inner(state, id).await
+}
+
+/// Internal implementation of [`delete_subscriber`].
+async fn delete_subscriber_inner(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<(), HandlerError> {
@@ -190,19 +233,19 @@ mod tests {
         };
 
         // Create
-        let res = create_subscriber(State(state.clone()), Json(payload))
+        let res = create_subscriber_inner(State(state.clone()), Json(payload))
             .await
             .unwrap();
         let id = res.subscriber.id;
         assert_eq!(res.links.self_link.href, format!("/subscribers/{}", id));
 
         // List
-        let list = list_subscribers(State(state.clone())).await.unwrap();
+        let list = list_subscribers_inner(State(state.clone())).await.unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].links.self_link.href, format!("/subscribers/{}", id));
 
         // Get
-        let get = get_subscriber(State(state.clone()), Path(id))
+        let get = get_subscriber_inner(State(state.clone()), Path(id))
             .await
             .unwrap();
         assert_eq!(get.subscriber.id, id);
@@ -214,7 +257,7 @@ mod tests {
             event_type: None,
             gh_app_installation_id: None,
         };
-        let updated = update_subscriber(State(state.clone()), Path(id), Json(update_payload))
+        let updated = update_subscriber_inner(State(state.clone()), Path(id), Json(update_payload))
             .await
             .unwrap();
         assert_eq!(
@@ -224,12 +267,12 @@ mod tests {
         assert_eq!(updated.links.self_link.href, format!("/subscribers/{}", id));
 
         // Delete
-        delete_subscriber(State(state.clone()), Path(id))
+        delete_subscriber_inner(State(state.clone()), Path(id))
             .await
             .unwrap();
 
         // Verify delete
-        let get_after_delete = get_subscriber(State(state.clone()), Path(id)).await;
+        let get_after_delete = get_subscriber_inner(State(state.clone()), Path(id)).await;
         assert!(get_after_delete.is_err());
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -42,6 +42,7 @@ fn map_to_hal(subscriber: Subscriber) -> SubscriberHal {
 /// # Metadata
 ///
 /// @tag subscribers
+#[allow(rustdoc::invalid_html_tags)]
 #[rovo]
 pub async fn create_subscriber(
     state: State<AppState>,
@@ -84,6 +85,7 @@ async fn create_subscriber_inner(
 /// # Metadata
 ///
 /// @tag subscribers
+#[allow(rustdoc::invalid_html_tags)]
 #[rovo]
 pub async fn list_subscribers(
     state: State<AppState>,
@@ -117,6 +119,7 @@ async fn list_subscribers_inner(
 /// # Metadata
 ///
 /// @tag subscribers
+#[allow(rustdoc::invalid_html_tags)]
 #[rovo]
 pub async fn get_subscriber(
     state: State<AppState>,
@@ -154,6 +157,7 @@ async fn get_subscriber_inner(
 /// # Metadata
 ///
 /// @tag subscribers
+#[allow(rustdoc::invalid_html_tags)]
 #[rovo]
 pub async fn update_subscriber(
     state: State<AppState>,
@@ -219,6 +223,7 @@ async fn update_subscriber_inner(
 /// # Metadata
 ///
 /// @tag subscribers
+#[allow(rustdoc::invalid_html_tags)]
 #[rovo]
 pub async fn delete_subscriber(
     state: State<AppState>,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -31,7 +31,17 @@ fn map_to_hal(subscriber: Subscriber) -> SubscriberHal {
     }
 }
 
-/// Stores a new [`Subscriber`] in the database.
+/// Create a new subscriber mapping.
+///
+/// Creates a new subscription mapping between a source branch and a target repository.
+///
+/// # Responses
+///
+/// 201: Json<SubscriberHal> - Subscriber created successfully
+///
+/// # Metadata
+///
+/// @tag subscribers
 #[rovo]
 pub async fn create_subscriber(
     state: State<AppState>,
@@ -63,7 +73,17 @@ async fn create_subscriber_inner(
     Ok(Json(map_to_hal(subscriber)))
 }
 
-/// Retrieves all [`Subscriber`]s.
+/// List all subscribers.
+///
+/// Returns a list of all subscriber mappings in the system.
+///
+/// # Responses
+///
+/// 200: Json<Vec<SubscriberHal>> - List of all subscribers
+///
+/// # Metadata
+///
+/// @tag subscribers
 #[rovo]
 pub async fn list_subscribers(
     state: State<AppState>,
@@ -81,13 +101,28 @@ async fn list_subscribers_inner(
     Ok(Json(subscribers.into_iter().map(map_to_hal).collect()))
 }
 
-/// Retrieves a specific [`Subscriber`] by ID.
+/// Get a single subscriber.
+///
+/// Retrieve a subscriber mapping by its ID.
+///
+/// # Path Parameters
+///
+/// id: The unique identifier of the subscriber
+///
+/// # Responses
+///
+/// 200: Json<SubscriberHal> - Successfully retrieved the subscriber
+/// 404: () - Subscriber was not found
+///
+/// # Metadata
+///
+/// @tag subscribers
 #[rovo]
 pub async fn get_subscriber(
     state: State<AppState>,
-    id: Path<i64>,
+    Path(id): Path<i64>,
 ) -> Result<Json<SubscriberHal>, HandlerError> {
-    get_subscriber_inner(state, id).await
+    get_subscriber_inner(state, Path(id)).await
 }
 
 /// Internal implementation of [`get_subscriber`].
@@ -103,14 +138,29 @@ async fn get_subscriber_inner(
     Ok(Json(map_to_hal(subscriber)))
 }
 
-/// Updates an existing [`Subscriber`].
+/// Update an existing subscriber.
+///
+/// Updates the target repository, event type, and/or GitHub App installation ID of a subscriber.
+///
+/// # Path Parameters
+///
+/// id: The unique identifier of the subscriber to update
+///
+/// # Responses
+///
+/// 200: Json<SubscriberHal> - Subscriber updated successfully
+/// 404: () - Subscriber was not found
+///
+/// # Metadata
+///
+/// @tag subscribers
 #[rovo]
 pub async fn update_subscriber(
     state: State<AppState>,
-    id: Path<i64>,
+    Path(id): Path<i64>,
     payload: Json<UpdateSubscriber>,
 ) -> Result<Json<SubscriberHal>, HandlerError> {
-    update_subscriber_inner(state, id, payload).await
+    update_subscriber_inner(state, Path(id), payload).await
 }
 
 /// Internal implementation of [`update_subscriber`].
@@ -153,10 +203,25 @@ async fn update_subscriber_inner(
     Ok(Json(map_to_hal(subscriber)))
 }
 
-/// Deletes a [`Subscriber`] by ID.
+/// Delete a subscriber.
+///
+/// Permanently deletes a subscriber mapping by its ID.
+///
+/// # Path Parameters
+///
+/// id: The unique identifier of the subscriber to delete
+///
+/// # Responses
+///
+/// 204: () - Subscriber deleted successfully
+/// 404: () - Subscriber was not found
+///
+/// # Metadata
+///
+/// @tag subscribers
 #[rovo]
-pub async fn delete_subscriber(state: State<AppState>, id: Path<i64>) -> Result<(), HandlerError> {
-    delete_subscriber_inner(state, id).await
+pub async fn delete_subscriber(state: State<AppState>, Path(id): Path<i64>) -> Result<(), HandlerError> {
+    delete_subscriber_inner(state, Path(id)).await
 }
 
 /// Internal implementation of [`delete_subscriber`].

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ async fn run_server(
         .await
         .map_err(FatalError::TcpBinding)?;
     println!("Server listening on http://{}", config.server.address);
+    println!("Scalar UI available at http://{}/scalar", config.server.address);
     axum::serve(listener, app)
         .await
         .map_err(FatalError::Serve)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,17 @@
     clippy::indexing_slicing
 )]
 
-use axum::body::Body;
-#[allow(unused_imports)]
 use axum::{
     Router,
-    http::{HeaderValue, Request, Response, header},
+    body::Body,
+    extract::State,
+    http::{HeaderValue, Request, Response, StatusCode, header},
     middleware::{self, Next},
-    routing::{delete, get, patch, post},
 };
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
+use rovo::Router as RovoRouter;
+use rovo::aide::openapi::OpenApi;
+use rovo::rovo;
 use tokio_util::sync::CancellationToken;
 use tower_http::timeout::TimeoutLayer;
 use tracing::error;
@@ -122,32 +124,55 @@ fn init_engines(ctx: &SharedContext, http_client: Client) -> Result<Vec<EngineTa
 
 /// Middleware to set Cache-Control header.
 async fn set_no_cache_header(req: Request<Body>, next: Next) -> Response<Body> {
+    let path = req.uri().path().to_string();
     let mut response = next.run(req).await;
-    response.headers_mut().insert(
-        header::CACHE_CONTROL,
-        HeaderValue::from_static("private, no-cache, no-store, must-revalidate, max-age=0"),
-    );
+    if path.starts_with("/subscribers") {
+        response.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("private, no-cache, no-store, must-revalidate, max-age=0"),
+        );
+    }
     response
+}
+
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
+mod health_handler {
+    use super::*;
+    #[rovo]
+    pub async fn health_check(State(_state): State<AppState>) -> &'static str {
+        "Relay Server is alive"
+    }
 }
 
 /// Builds the application router.
 pub fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
     let state = AppState { db_pool: pool };
 
-    let subscribers = Router::new()
-        .route("/", post(create_subscriber).get(list_subscribers))
+    let mut api = OpenApi::default();
+    api.info.title = "Relay API".to_string();
+    api.info.description =
+        Some("API for managing repository subscribers and triggering workflows".to_string());
+
+    let subscribers = RovoRouter::<AppState>::new()
+        .route(
+            "/",
+            rovo::routing::post(create_subscriber).get(list_subscribers),
+        )
         .route(
             "/{id}",
-            get(get_subscriber)
+            rovo::routing::get(get_subscriber)
                 .patch(update_subscriber)
                 .delete(delete_subscriber),
-        )
-        .layer(middleware::from_fn(set_no_cache_header));
+        );
 
-    Router::new()
-        .route("/health", get(|| async { "Relay Server is alive" }))
+    RovoRouter::<AppState>::new()
+        .route("/health", rovo::routing::get(health_handler::health_check))
         .nest("/subscribers", subscribers)
+        .with_oas(api)
+        .with_scalar("/scalar")
         .with_state(state)
+        .finish()
+        .layer(middleware::from_fn(set_no_cache_header))
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,
             config.server.in_request_timeout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,10 @@ async fn run_server(
         .await
         .map_err(FatalError::TcpBinding)?;
     println!("Server listening on http://{}", config.server.address);
-    println!("Scalar UI available at http://{}/scalar", config.server.address);
+    println!(
+        "Scalar UI available at http://{}/scalar",
+        config.server.address
+    );
     axum::serve(listener, app)
         .await
         .map_err(FatalError::Serve)?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,11 +3,12 @@
 //! The `Create_` `struct`s represent the payload
 //! to create the corresponding row.
 
+use rovo::schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
 /// Represents a row in the `branches` table.
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Serialize, Deserialize, FromRow, JsonSchema)]
 pub struct Branch {
     /// Unique database primary key.
     pub id: i64,
@@ -31,7 +32,7 @@ pub struct Branch {
 }
 
 /// Represents a row in the `subscribers` table.
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Serialize, Deserialize, FromRow, JsonSchema)]
 pub struct Subscriber {
     /// Unique database primary key.
     pub id: i64,
@@ -64,14 +65,14 @@ pub struct Subscriber {
 }
 
 /// HAL link structure.
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 pub struct HalLink {
     /// URL of the link.
     pub href: String,
 }
 
 /// HAL links for a subscriber.
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 pub struct SubscriberLinks {
     /// Self link.
     #[serde(rename = "self")]
@@ -83,7 +84,7 @@ pub struct SubscriberLinks {
 }
 
 /// HAL representation of a subscriber.
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 pub struct SubscriberHal {
     /// The subscriber data.
     #[serde(flatten)]
@@ -94,7 +95,7 @@ pub struct SubscriberHal {
 }
 
 /// Holds payload data for the creation of a [`Subscriber`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateSubscriber {
     /// Determines the value of [`Branch::repo_url`].
     pub source_repo_url: String,
@@ -113,7 +114,7 @@ pub struct CreateSubscriber {
 }
 
 /// Holds payload data for the update of a [`Subscriber`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateSubscriber {
     /// Determines the value of [`Subscriber::target_repo`].
     pub target_repo: Option<String>,


### PR DESCRIPTION
- Closes #46

I ultimately opted for Scalar instead of Swagger UI for better aesthetics, and I used `rovo` instead of `utoipa`, because of its ability to implicitly discover API endpoints, reducing the risk of documentation desynchronization.

**Technical impact.** Since `rovo` requires its own router structure to be finalized before building the final Axum `Router`, I have moved the `set_no_cache` middleware from the `subscribers` nested router to the root router. I edited the middleware to filter setting the `cache-control` header based on path, so the behavior should remain unchanged.