### PR TITLE
Add `TaskTracker` to gracefully shutdown engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,6 +3147,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.149"
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls", "macros", "chrono" ] }
 thiserror = "2.0.18"
 tokio = { version = "1.51.1", features = ["process", "rt-multi-thread", "signal"] }
-tokio-util = "0.7.18"
+tokio-util = { version = "0.7.18", features = ["rt"] }
 tower = { version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.6", features = ["timeout"] }
 tracing = "0.1.44"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,7 @@
 //! Interface definitions for async engines.
 
 use async_trait::async_trait;
+use tokio_util::task::TaskTracker;
 
 use tracing::info;
 
@@ -12,9 +13,9 @@ pub trait AsyncEngine: Send + Sync + 'static {
 }
 
 /// Starts the engine by spawning it in a new task.
-pub fn start_engine(engine: Box<dyn AsyncEngine>, message: &str) {
+pub fn start_engine(engine: Box<dyn AsyncEngine>, message: &str, tracker: &TaskTracker) {
     info!(message);
-    tokio::spawn(async move {
+    tracker.spawn(async move {
         engine.run().await;
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use rovo::aide::openapi::OpenApi;
 use rovo::rovo;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tower_http::timeout::TimeoutLayer;
 use tracing::{error, info};
 
@@ -56,14 +57,20 @@ mod trigger;
 
 #[tokio::main]
 async fn main() {
-    run_app().await.unwrap_or_else(|e| error!("{e}"));
+    let tracker = TaskTracker::new();
+
+    run_app(&tracker).await.unwrap_or_else(|e| error!("{e}"));
+
+    tracker.close();
+    tracker.wait().await;
+    info!("All systems terminated. Terminating process.")
 }
 
 /// A task for an engine to be started.
 type EngineTask = (Box<dyn AsyncEngine>, &'static str);
 
 /// Runs the server, delegating errors to the caller.
-async fn run_app() -> Result<(), FatalError> {
+async fn run_app(tracker: &TaskTracker) -> Result<(), FatalError> {
     tracing_subscriber::fmt::init();
 
     #[cfg(debug_assertions)]
@@ -79,7 +86,7 @@ async fn run_app() -> Result<(), FatalError> {
 
     let engines = init_engines(&ctx, http_client)?;
     for (engine, message) in engines {
-        crate::engine::start_engine(engine, message);
+        crate::engine::start_engine(engine, message, tracker);
     }
 
     let app = build_router(pool, &config);


### PR DESCRIPTION
This ensures that the tasks associated with the `AsyncEngine`s have terminated before terminating the process.