### PR TITLE
Manage `CancellationToken` at the app boundary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,12 +64,12 @@ pub mod trigger;
 type EngineTask = (Box<dyn AsyncEngine>, &'static str);
 
 /// Runs the server, delegating errors to the caller.
-pub async fn run_app(tracker: &TaskTracker) -> Result<(), FatalError> {
+pub async fn run_app(tracker: &TaskTracker, token: &CancellationToken) -> Result<(), FatalError> {
     let config = Config::load()?;
     let pool = init_database(&config).await?;
     let http_client = build_http_client(&config)?;
 
-    let ctx = init_context(pool.clone(), config.clone());
+    let ctx = init_context(pool.clone(), config.clone(), token.clone());
 
     crate::trigger::recover_stuck_tasks(&pool, &config).await?;
 
@@ -80,7 +80,7 @@ pub async fn run_app(tracker: &TaskTracker) -> Result<(), FatalError> {
 
     let app = build_router(pool, &config);
 
-    run_server(app, ctx.token.clone(), &ctx.config).await
+    run_server(app, &ctx.config).await
 }
 
 /// Initializes the database pool.
@@ -98,10 +98,9 @@ async fn init_database(config: &Config) -> Result<sqlx::SqlitePool, FatalError> 
 }
 
 /// Initializes the shared application context.
-fn init_context(pool: sqlx::SqlitePool, config: Config) -> SharedContext {
-    let token = CancellationToken::new();
+fn init_context(pool: sqlx::SqlitePool, config: Config, token: CancellationToken) -> SharedContext {
     SharedContext {
-        config: config.clone(),
+        config,
         db_pool: pool,
         token,
         git_fetcher: std::sync::Arc::new(crate::polling::git::MainGitFetcher),
@@ -231,11 +230,7 @@ pub fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
 }
 
 /// Runs the server.
-async fn run_server(
-    app: Router,
-    token: CancellationToken,
-    config: &Config,
-) -> Result<(), FatalError> {
+async fn run_server(app: Router, config: &Config) -> Result<(), FatalError> {
     let listener = tokio::net::TcpListener::bind(config.server.address)
         .await
         .map_err(FatalError::TcpBinding)?;
@@ -249,8 +244,6 @@ async fn run_server(
         .with_graceful_shutdown(shutdown_signal())
         .await
         .map_err(FatalError::Serve)?;
-
-    token.cancel();
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 )]
 
 use relay::run_app;
-use tokio_util::task::TaskTracker;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{error, info};
 
 #[tokio::main]
@@ -20,9 +20,13 @@ async fn main() {
     tracing::warn!("APPLICATION IS RUNNING IN DEBUG MODE.");
 
     let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
 
-    run_app(&tracker).await.unwrap_or_else(|e| error!("{e}"));
+    run_app(&tracker, &token)
+        .await
+        .unwrap_or_else(|e| error!("{e}"));
 
+    token.cancel();
     tracker.close();
     tracker.wait().await;
     info!("All systems terminated. Terminating process.")


### PR DESCRIPTION
Moves the `CancellationToken` to the `main` function, and cancels it unconditionally before closing the `TaskTracker` ensuring all code paths leads to the cancellation of the token. In fact, if a `FatalError` prevented the line `token.cancel();` from running in `run_server`, it would result in a deadlock where the `TaskTracker` would infinitely wait for the `AsyncEngines` to terminate.