### PR TITLE
Store PEM key into `GitHubAuthenticator`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,14 @@ pub enum FatalError {
     #[error("Environment variable '{0}' not set")]
     EnvVarNotSet(String),
 
+    /// Could not load the authentication key.
+    #[error("Failed to load authentication key: {0}")]
+    AuthKeyLoading(#[source] jsonwebtoken::errors::Error),
+
+    /// Could not read the authentication key file.
+    #[error("Failed to read authentication key file: {0}")]
+    AuthKeyIo(#[source] std::io::Error),
+
     /// Configuration is invalid.
     #[error(transparent)]
     Setup(SetupError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
     clippy::indexing_slicing
 )]
 
+use std::fs;
 use std::str::FromStr;
 
 use axum::{
@@ -18,6 +19,7 @@ use axum::{
     middleware::{self, Next},
     response::IntoResponse,
 };
+use jsonwebtoken::EncodingKey;
 use reqwest::Client;
 use rovo::Router as RovoRouter;
 use rovo::aide::openapi::OpenApi;
@@ -111,9 +113,13 @@ fn init_context(pool: sqlx::SqlitePool, config: Config, token: CancellationToken
 fn init_engines(ctx: &SharedContext, http_client: Client) -> Result<Vec<EngineTask>, FatalError> {
     let polling_engine = PollingEngine { ctx: ctx.clone() };
 
+    let pem = fs::read(&ctx.config.auth.pem_path).map_err(FatalError::AuthKeyIo)?;
+    let encoding_key = EncodingKey::from_rsa_pem(&pem).map_err(FatalError::AuthKeyLoading)?;
+
     let authenticator = Box::new(GitHubAuthenticator {
         http_client: http_client.clone(),
         config: ctx.config.clone(),
+        encoding_key,
     });
     let trigger_engine = TriggerEngine {
         ctx: ctx.clone(),

--- a/src/trigger/auth.rs
+++ b/src/trigger/auth.rs
@@ -26,6 +26,9 @@ pub struct GitHubAuthenticator {
 
     /// Application configuration.
     pub config: Config,
+
+    /// The key to sign JWTs.
+    pub encoding_key: EncodingKey,
 }
 
 #[async_trait]
@@ -34,7 +37,7 @@ impl Authenticator for GitHubAuthenticator {
         &self,
         subscriber: &Subscriber,
     ) -> Result<String, AuthError> {
-        let jwt = generate_gh_jwt(&self.config)?;
+        let jwt = generate_gh_jwt(&self.encoding_key, &self.config)?;
         request_iat(&self.http_client, &jwt, subscriber, &self.config).await
     }
 }
@@ -63,10 +66,7 @@ struct GitHubClaims {
 ///
 /// <!-- LINKS -->
 /// [jwt_docs]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
-pub(super) fn generate_gh_jwt(config: &Config) -> Result<String, AuthError> {
-    // TODO: Check if you should use Tokio API.
-    let pem = std::fs::read(&config.auth.pem_path)?;
-
+pub(super) fn generate_gh_jwt(key: &EncodingKey, config: &Config) -> Result<String, AuthError> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();
@@ -77,9 +77,8 @@ pub(super) fn generate_gh_jwt(config: &Config) -> Result<String, AuthError> {
     };
 
     let header = Header::new(Algorithm::RS256);
-    let key = EncodingKey::from_rsa_pem(&pem)?;
 
-    let jwt = encode(&header, &claims, &key)?;
+    let jwt = encode(&header, &claims, key)?;
     Ok(jwt)
 }
 


### PR DESCRIPTION
Avoids recomputing the `EncodingKey` from the PEM file each time a request is sent to the GitHub API, hoisting it to the initialization phase and storing it into `GitHubAuthenticator`.