### PR TITLE
Mitigate `git` injection attacks

### DIFF
--- a/src/polling/git.rs
+++ b/src/polling/git.rs
@@ -25,7 +25,7 @@ impl GitFetcher for MainGitFetcher {
         branch: &str,
     ) -> Result<CommitHash, CommitHashError> {
         tokio::process::Command::new("git")
-            .args(["ls-remote", repo_url, branch])
+            .args(["ls-remote", "--", repo_url, branch])
             .output()
             .await
             .map_err(CommitHashError::from)


### PR DESCRIPTION
Adds a double hyphen (`--`) after `git ls-remote` to treat the repository URL and branch name as literal, so an attacker cannot use those fields to inject options.