### PR TITLE
Eliminate data race on branch upsert

### DIFF
--- a/migrations/20260611141508_add_unique_index_to_branches.sql
+++ b/migrations/20260611141508_add_unique_index_to_branches.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_branches_repo_url_name ON branches(repo_url, name);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -270,12 +270,16 @@ async fn get_or_insert_branch_id(
         return Ok(id);
     }
 
-    sqlx::query_scalar::<_, i64>("INSERT INTO branches (repo_url, name) VALUES (?, ?) RETURNING id")
-        .bind(&payload.source_repo_url)
-        .bind(&payload.source_branch_name)
-        .fetch_one(&mut *transaction)
-        .await
-        .map_err(Into::into)
+    sqlx::query_scalar::<_, i64>(
+        "INSERT INTO branches (repo_url, name) VALUES (?, ?) \
+         ON CONFLICT(repo_url, name) DO UPDATE SET repo_url=excluded.repo_url \
+         RETURNING id",
+    )
+    .bind(&payload.source_repo_url)
+    .bind(&payload.source_branch_name)
+    .fetch_one(&mut *transaction)
+    .await
+    .map_err(Into::into)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`get_or_insert_branch_id` implemented a check-then-act anti-pattern which caused a race condition. This PR adds an `ON CONFLICT` clause to merge the two operations into one.