### PR TITLE
Explicitly enable SQLite Write-Ahead Logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ pub async fn run_app(tracker: &TaskTracker, token: &CancellationToken) -> Result
 
 /// Initializes the database pool.
 async fn init_database(config: &Config) -> Result<sqlx::SqlitePool, FatalError> {
-    let options = SqliteConnectOptions::from_str(config.database.url.as_str())?.foreign_keys(true);
+    let options = SqliteConnectOptions::from_str(config.database.url.as_str())?
+        .foreign_keys(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
 
     let pool = sqlx::sqlite::SqlitePoolOptions::new()
         .acquire_timeout(config.database.timeout)


### PR DESCRIPTION
Write-Ahead Logging (WAL) enables readers and writers to not block each others, by writing changes ahead on a log file. While sometimes SQLx might enable WAL by default, this change enforces it on database connection.