### PR TITLE
Remove duplicated elements from `AppState`

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -375,8 +375,6 @@ mod tests {
         let state = AppState {
             config: std::sync::Arc::new(config),
             db_pool: pool.clone(),
-            api_key: None,
-            allow_unauthenticated: false,
         };
         let payload = CreateSubscriber {
             source_repo_url: RepoUrl::new("https://github.com/org/repo".to_string()).unwrap(),
@@ -450,8 +448,6 @@ mod tests {
         let state = AppState {
             config: std::sync::Arc::new(config),
             db_pool: pool.clone(),
-            api_key: None,
-            allow_unauthenticated: false,
         };
 
         // Create 3 subscribers
@@ -505,8 +501,6 @@ mod tests {
         let state = AppState {
             config: std::sync::Arc::new(config),
             db_pool: pool.clone(),
-            api_key: None,
-            allow_unauthenticated: false,
         };
         let payload = CreateSubscriber {
             source_repo_url: RepoUrl::new("https://github.com/org/repo".to_string()).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,12 +142,12 @@ async fn auth_middleware(
     next: Next,
 ) -> Response<Body> {
     let needs_authentication =
-        req.uri().path().starts_with("/subscribers") && !state.allow_unauthenticated;
+        req.uri().path().starts_with("/subscribers") && !state.config.auth.allow_unauthenticated;
 
     if needs_authentication {
         let auth_header = req.headers().get("X-API-KEY").and_then(|v| v.to_str().ok());
 
-        if !verify_api_key(state.api_key.as_ref(), auth_header) {
+        if !verify_api_key(state.config.auth.api_key.as_ref(), auth_header) {
             return StatusCode::UNAUTHORIZED.into_response();
         }
     }
@@ -202,8 +202,6 @@ pub fn build_router(pool: sqlx::SqlitePool, config: &Config) -> Router {
     let state = AppState {
         config: std::sync::Arc::new(config.clone()),
         db_pool: pool,
-        api_key: config.auth.api_key.clone(),
-        allow_unauthenticated: config.auth.allow_unauthenticated,
     };
 
     let mut api = OpenApi::default();

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,6 @@
 //! State of the application.
 
 use crate::config::Config;
-use crate::domain::NonEmptyString;
 use std::sync::Arc;
 
 /// Holds data accessible from each [handler].
@@ -15,10 +14,4 @@ pub struct AppState {
 
     /// SQLx connection pool for the SQLite database.
     pub db_pool: sqlx::SqlitePool,
-
-    /// Optional API key for authentication.
-    pub api_key: Option<NonEmptyString>,
-
-    /// Allow unauthenticated access to the API.
-    pub allow_unauthenticated: bool,
 }


### PR DESCRIPTION
`AppState` contained some elements already in `Config`. This PR removes a couple of fields from `AppState`.